### PR TITLE
demo_ruby: fix traceback when changing themes

### DIFF
--- a/Dbus/demos/demo_ruby/demo_ruby
+++ b/Dbus/demos/demo_ruby/demo_ruby
@@ -105,7 +105,7 @@ class Applet < CDApplet
 	end
 	def reload
 		p "[+] our module was reloaded, welcome back!"
-		self.icon.AddDataRenderer("gauge", 1, myApplet.config['theme'])
+		self.icon.AddDataRenderer("gauge", 1, self.configuration['theme'])
 		self.icon.RenderValues([Float(self.counter)/self.configuration['max_value']])
 		self.sub_icons.RemoveSubIcon("any")
 		self.sub_icons.AddSubIcons(["icon 1", "firefox-3.0", "id1", "icon 2", "natilus", "id2", "icon 3", "thunderbird", "id3"]) 


### PR DESCRIPTION
Fix the "crash" when changing like:
./demo_ruby:108:in `reload': undefined local variable or method `myApplet' for #<Applet:0x00000002e6c060> (NameError)
        from /usr/share/ruby/vendor_ruby/CDApplet.rb:203:in `_on_reload'
        from /usr/share/ruby/vendor_ruby/CDApplet.rb:274:in `block in _connect_to_dock'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/introspect.rb:325:in `call'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/introspect.rb:325:in `block in on_signal'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/bus.rb:665:in `call'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/bus.rb:665:in `block in process'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/bus.rb:663:in `each'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/bus.rb:663:in `process'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/bus.rb:855:in `block in run'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/bus.rb:846:in `each'
        from /usr/share/gems/gems/ruby-dbus-0.9.0/lib/dbus/bus.rb:846:in `run'
        from /usr/share/ruby/vendor_ruby/CDApplet.rb:83:in `run'
        from ./demo_ruby:127:in `<main>'