### PR TITLE
RFE: Default to xdg-screensaver for lock_screen

### DIFF
--- a/gvfs-integration/cairo-dock-gio-vfs.c
+++ b/gvfs-integration/cairo-dock-gio-vfs.c
@@ -1566,6 +1566,14 @@ static GList *cairo_dock_gio_vfs_list_apps_for_file (const gchar *cBaseURI)
 	return pList;
 }
 
+static void cairo_dock_gio_vfs_lock_screen (void) {
+	gchar *cResult = cairo_dock_launch_command_sync ("which xdg-screensaver");
+	if (cResult != NULL && *cResult == '/')
+		cairo_dock_launch_command ("xdg-screensaver lock");
+
+	g_free (cResult);
+}
+
 gboolean cairo_dock_gio_vfs_fill_backend(CairoDockDesktopEnvBackend *pVFSBackend)
 {
 	if(pVFSBackend)
@@ -1590,6 +1598,7 @@ gboolean cairo_dock_gio_vfs_fill_backend(CairoDockDesktopEnvBackend *pVFSBackend
 		pVFSBackend->empty_trash = cairo_dock_gio_vfs_empty_trash;
 		pVFSBackend->get_desktop_path = cairo_dock_gio_vfs_get_desktop_path;
 		pVFSBackend->list_apps_for_file = cairo_dock_gio_vfs_list_apps_for_file;
+		pVFSBackend->lock_screen = cairo_dock_gio_vfs_lock_screen;
 	}
 
 	return TRUE;


### PR DESCRIPTION
Well, I usually use LXDE so no integration plug-ins are enabled. Actually although cairo-dock settings shows "gnome-integration" icon, it is grayed out and when I
- add "logout" plugin
- choose "logout -> lock screen"
screen isn't locked.

However (I use LXDE on Fedora and) LXDE user installs xscreensaver and xdg-utils, and I guess other xscreensaver fans also use it on other DE users. As xdg-utils is maintained by freedesktop.org and xdg-screensaver lock chooses lock screen command (so when xscreensaver is running it actually launches xscreensaver-command -lock), I think it is preferable that lock_screen defauls to xdg-screensaver, when no integration plugin is activated.