### PR TITLE
Indicator: switch to Ayatana indicator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ endif()
 ## libido
 enable_if_not_defined (enable-libido-support)
 if (enable-libido-support)
-	set (IDO_MODULE libido3-0.1)
+	set (IDO_MODULE libayatana-ido3-0.4)
 	pkg_check_modules (IDO ${IDO_MODULE})
 	if (IDO_FOUND)
 		STRING (REGEX REPLACE "\\..*" "" IDO_MAJOR "${IDO_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,10 +197,10 @@ endif()
 ## Indicator
 enable_if_not_defined (enable-indicator-support)
 if (enable-indicator-support)
-	set (INDICATOR_APPLET_MODULE indicator3-0.4)
+	set (INDICATOR_APPLET_MODULE ayatana-indicator3-0.4)
 	pkg_check_modules (INDICATOR_APPLET ${INDICATOR_APPLET_MODULE})
 	if (INDICATOR_APPLET_FOUND)
-		set (INDICATOR_NEW_VERSION TRUE)  # oneiric and newer
+		set (INDICATOR_NEW_VERSION TRUE)  # bionic and newer
 	else()
 		set (INDICATOR_APPLET_MODULE indicator3)
 		pkg_check_modules (INDICATOR_APPLET ${INDICATOR_APPLET_MODULE})
@@ -262,12 +262,12 @@ if (INDICATOR_APPLET_FOUND)
 		set (INDICATOR_MESSAGES_HAS_LOZENGE 0)
 	endif()
 
-	if (INDICATOR_NEW_VERSION)  # oneiric and newer
+	if (INDICATOR_NEW_VERSION)  # bionic and newer
 		execute_process(
-			COMMAND pkg-config --variable=iconsdir indicator3-0.4
+			COMMAND pkg-config --variable=iconsdir ayatana-indicator3-0.4
 			OUTPUT_VARIABLE INDICATORICONSDIR)
 		execute_process(
-			COMMAND pkg-config --variable=indicatordir indicator3-0.4
+			COMMAND pkg-config --variable=indicatordir ayatana-indicator3-0.4
 			OUTPUT_VARIABLE INDICATORDIR)
 		STRING (REGEX REPLACE "\n" "" INDICATORDIR ${INDICATORDIR})
 		set (with_indicator3 yes)

--- a/Indicator-applet/indicator-applet.h
+++ b/Indicator-applet/indicator-applet.h
@@ -23,9 +23,9 @@
 
 #include <cairo-dock.h>
 
-#include <libindicator/indicator.h>
+#include <libayatana-indicator/indicator.h>
 ///#include <libindicator/indicator-object.h>
-#include <libindicator/indicator-service-manager.h>
+#include <libayatana-indicator/indicator-service-manager.h>
 
 #include <libdbusmenu-gtk/menuitem.h>
 #include <libdbusmenu-gtk/menu.h>

--- a/Indicator-applet3/indicator-applet3-utils.h
+++ b/Indicator-applet3/indicator-applet3-utils.h
@@ -22,7 +22,7 @@
 
 #include <gtk/gtk.h>
 #include <cairo-dock.h>
-#include <libindicator/indicator-object.h>
+#include <libayatana-indicator/indicator-object.h>
 
 /**
  * Use the image of a GtkImage to draw a Cairo-Dock Icon

--- a/Indicator-applet3/indicator-applet3.h
+++ b/Indicator-applet3/indicator-applet3.h
@@ -22,7 +22,7 @@
 
 #include <glib.h>
 #include <gtk/gtk.h>
-#include <libindicator/indicator-object.h>
+#include <libayatana-indicator/indicator-object.h>
 
 #define INDICATOR_SERVICE_DIR "/usr/share/unity/indicators"
 

--- a/MeMenu/src/applet-me.c
+++ b/MeMenu/src/applet-me.c
@@ -23,9 +23,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <libindicator/indicator.h>
-#include <libindicator/indicator-object.h>
-#include <libindicator/indicator-service-manager.h>
+#include <libayatana-indicator/indicator.h>
+#include <libayatana-indicator/indicator-object.h>
+#include <libayatana-indicator/indicator-service-manager.h>
 
 #include "applet-struct.h"
 #include "me-service-client.h"

--- a/MeMenu/src/applet-menu.c
+++ b/MeMenu/src/applet-menu.c
@@ -30,7 +30,7 @@
 
 #include <libdbusmenu-gtk/menuitem.h>
 #include <libdbusmenu-gtk/menu.h>
-#include <libido/idoentrymenuitem.h>
+#include <libayatana-ido/idoentrymenuitem.h>
 
 #if (DBUSMENU_MAJOR > 0 || DBUSMENU_MINOR >= 2)
 static void

--- a/alsaMixer/src/applet-menu.c
+++ b/alsaMixer/src/applet-menu.c
@@ -38,9 +38,9 @@
 
 #include <libdbusmenu-gtk/menuitem.h>
 #include <libdbusmenu-gtk/menu.h>
-#include <libido/idoscalemenuitem.h>
+#include <libayatana-ido/idoscalemenuitem.h>
 
-#include <libido/libido.h>
+#include <libayatana-ido/libayatana-ido.h>
 
 static gboolean
 new_transport_widget (DbusmenuMenuitem * newitem,

--- a/alsaMixer/src/voip-input-widget.c
+++ b/alsaMixer/src/voip-input-widget.c
@@ -27,7 +27,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <glib.h>
 #include "voip-input-widget.h"
 #include "common-defs.h"
-#include <libido/idoscalemenuitem.h>
+#include <libayatana-ido/idoscalemenuitem.h>
 
 typedef struct _VoipInputWidgetPrivate VoipInputWidgetPrivate;
 

--- a/alsaMixer/src/volume-widget.c
+++ b/alsaMixer/src/volume-widget.c
@@ -27,7 +27,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <glib.h>
 #include "volume-widget.h"
 #include "common-defs.h"
-#include <libido/idoscalemenuitem.h>
+#include <libayatana-ido/idoscalemenuitem.h>
 ///#include "indicator-sound.h"
 #include "applet-backend-sound-menu-old.h"
 


### PR DESCRIPTION
libindicator is deprecated and it should be
migrated to maintained upstream. at least
Ubuntu bionic or later is supported (packaged).

https://ayatanaindicators.github.io/