### PR TITLE
Weather applet: fix missing symbol on libcd-weather.so

### DIFF
--- a/weather/src/applet-config.c
+++ b/weather/src/applet-config.c
@@ -61,7 +61,9 @@ void cd_weather_reset_all_datas (GldiModuleInstance *myApplet)
 	
 	cd_weather_reset_data (myApplet);
 	
+#ifdef CD_WEATHER_HAS_CODE_LOCATION
 	cd_weather_free_location_list ();
+#endif
 	
 	CD_APPLET_DELETE_MY_ICONS_LIST;
 	


### PR DESCRIPTION
The macro CD_WEATHER_HAS_CODE_LOCATION is currently undefined,
so cd_weather_free_location_list() symbol is not compiled in
libcd-weather.so .

So cd_weather_reset_all_datas() should not be called in
cd_weather_reset_all_datas().