### PR TITLE
Double definition of my_fRainbowColor

### DIFF
--- a/dock-rendering/src/rendering-config.c
+++ b/dock-rendering/src/rendering-config.c
@@ -26,7 +26,7 @@
 #include "rendering-rainbow.h"
 
 extern int iVanishingPointY;
-extern double my_fRainbowColor[4];
+//extern double my_fRainbowColor[4];
 
 extern double my_fInclinationOnHorizon;
 extern double my_fForegroundRatio;


### PR DESCRIPTION
Comment in line 29, to avoid duplicate in definition of variable my_fRainbowColor. Affects previous versions of cairo-dock-plugins. Solved same issue in version 3.4.1 adding comment before definition of variables : my_fRainbowColor and my_fRainbowLineColor.