### PR TITLE
Duplicate definition of variables

### DIFF
--- a/dock-rendering/src/rendering-config.c
+++ b/dock-rendering/src/rendering-config.c
@@ -25,9 +25,10 @@
 #include "rendering-config.h"
 #include "rendering-rainbow.h"
 
-extern int iVanishingPointY;double my_fRainbowColor[4];
+extern int iVanishingPointY;
+/*double my_fRainbowColor[4];
 double my_fRainbowLineColor[4];
-
+*/
 extern double my_fInclinationOnHorizon;
 extern double my_fForegroundRatio;
 extern double my_iGapOnEllipse;


### PR DESCRIPTION
Adding multi line comment, between line 28 and 29 to avoid duplicate of definition of variables my_fRainbowColor and my_fRainbowLineColor. This change solves issues at build time.