### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/Dbus/interfaces/bash/setup.py
+++ b/Dbus/interfaces/bash/setup.py
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 # http://www.gnu.org/licenses/licenses.html#GPL
 
-from distutils.core import setup
+from setuptools import setup
 setup(name='CDBashApplet',
 		version='1.0',
 		license='GPL-3',

--- a/Dbus/interfaces/python/setup.py
+++ b/Dbus/interfaces/python/setup.py
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 # http://www.gnu.org/licenses/licenses.html#GPL
 
-from distutils.core import setup
+from setuptools import setup
 setup(name='CDApplet',
 		version='1.0',
 		license='GPL-3',


### PR DESCRIPTION
distutils is no more as of Python 3.12; setuptools is the simplest migration option [1] although it does add a dependency to the project

[1]: https://peps.python.org/pep-0632/#migration-advice