### PR TITLE
Improve desktop integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -914,7 +914,7 @@ endif()
 ############# LOGOUT #################
 message (STATUS "> Logout:")
 set (GETTEXT_LOGOUT ${GETTEXT_PLUGINS})
-set (VERSION_LOGOUT "2.0.4")
+set (VERSION_LOGOUT "2.1.0")
 set (PACKAGE_LOGOUT "cd-logout")
 set (logoutdatadir "${pluginsdatadir}/logout")
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/logout/data/logout.conf.in ${CMAKE_CURRENT_BINARY_DIR}/logout/data/logout.conf)

--- a/Dbus/data/cairo-dock-launcher-API-daemon.py
+++ b/Dbus/data/cairo-dock-launcher-API-daemon.py
@@ -18,10 +18,6 @@
 
 import sys
 
-from gi.repository import GLib as glib
-from gi.repository import GObject as gobject
-g_bMainLoopInGObject = False
-
 import re
 from os import popen, getpid
 import dbus, dbus.service
@@ -161,12 +157,8 @@ class ULWatcher:
 		self.bus.add_signal_receiver (self.on_launcher_entry_signal, dbus_interface=self.bus_iface_str, member_keyword='member', sender_keyword='sender')
 		
 		self.dock = CairoDock()
-		
-		if g_bMainLoopInGObject:
-			self.loop = gobject.MainLoop()
-		else:
-			self.loop = glib.MainLoop()
-		self.loop.run()
+		if self.dock.iface:
+			self.dock.loop.run()
 	
 	def on_launcher_entry_signal(self, val1=None, val2=None, member=None, sender=None):  # application://evolution.desktop, dictionnary (sv)
 		if (member == 'Update'):

--- a/Dbus/interfaces/python/CairoDock.py
+++ b/Dbus/interfaces/python/CairoDock.py
@@ -21,6 +21,8 @@
 import os.path
 import dbus
 import re
+import gi
+from gi.repository import GLib as glib
 from dbus.mainloop.glib import DBusGMainLoop
 
 USER_CONFIG_DIR = os.path.expanduser("~/.config")
@@ -113,6 +115,7 @@ class CairoDock:
 		self.cObjectPath = '/org/'+name1+'/'+name2
 		
 		## connect to the dock
+		self.loop = glib.MainLoop()
 		self.bus = dbus.SessionBus()
 		self._connect()
 		
@@ -125,6 +128,7 @@ class CairoDock:
 			if self.iface != None:
 				self.iface = None
 				print("-> no more connection to "+self.cAppName)
+				self.loop.quit()
 		elif self.iface == None:
 			self._connect()
 	

--- a/gnome-integration/src/applet-init.c
+++ b/gnome-integration/src/applet-init.c
@@ -60,7 +60,9 @@ CD_APPLET_DEFINE2_BEGIN ("gnome integration",
 			pVFSBackend->shutdown = env_backend_shutdown;
 			pVFSBackend->reboot = env_backend_shutdown;
 		}
-		pVFSBackend->lock_screen = env_backend_lock_screen;
+		// this calls shared-files/scripts/lock-screen.sh which will not work on Wayland
+		if (! gldi_container_is_wayland_backend ())
+			pVFSBackend->lock_screen = env_backend_lock_screen;
 		pVFSBackend->setup_time = env_backend_setup_time;
 		pVFSBackend->show_system_monitor = env_backend_show_system_monitor;
 	}

--- a/logout/data/logout.conf.in
+++ b/logout/data/logout.conf.in
@@ -143,5 +143,8 @@ user action2 =
 #{Leave empty to execute the default command. If not empty, it will execute this command with the name of the user (or nothing for guest session)}
 user action switch =
 
+#s Custom command to lock the screen:
+#{Leave empty to execute the default command (if not empty, this is preferred).}
+user action lock =
 
 shutdown time = 0

--- a/logout/src/applet-config.c
+++ b/logout/src/applet-config.c
@@ -32,6 +32,7 @@ CD_APPLET_GET_CONFIG_BEGIN
 	myConfig.cUserAction = CD_CONFIG_GET_STRING ("Configuration", "user action");
 	myConfig.cUserActionShutdown = CD_CONFIG_GET_STRING ("Configuration", "user action2");
 	myConfig.cUserActionSwitchUser = CD_CONFIG_GET_STRING ("Configuration", "user action switch");
+	myConfig.cUserActionLock = CD_CONFIG_GET_STRING ("Configuration", "user action lock");
 	myConfig.iShutdownTime = CD_CONFIG_GET_INTEGER ("Configuration", "shutdown time");
 	myConfig.cEmblemPath = CD_CONFIG_GET_STRING ("Configuration", "emblem");
 	myConfig.cDefaultLabel = CD_CONFIG_GET_STRING ("Icon", "name");

--- a/logout/src/applet-logout.c
+++ b/logout/src/applet-logout.c
@@ -49,6 +49,7 @@ static void cd_logout_hybridSleep (void);
 static void cd_logout_close_session (void);
 static void cd_logout_switch_to_user (const gchar *cUser);
 static void cd_logout_switch_to_guest (void);
+static void cd_logoout_lock_screen (void);
 //static gboolean cd_logout_switch_to_greeter (void);
 
 static void _free_user (CDUser *pUser);
@@ -414,7 +415,7 @@ static GtkWidget *_build_menu (GtkWidget **pShutdownMenuItem)
 	CD_APPLET_ADD_SEPARATOR_IN_MENU (pMenu);
 	
 	cImagePath = cd_logout_check_icon ("system-lock-screen", myData.iDesiredIconSize);
-	CD_APPLET_ADD_IN_MENU_WITH_STOCK (D_("Lock screen"), cImagePath ? cImagePath : MY_APPLET_SHARE_DATA_DIR"/locked.svg", cairo_dock_fm_lock_screen, pMenu);  /// TODO: same question...
+	CD_APPLET_ADD_IN_MENU_WITH_STOCK (D_("Lock screen"), cImagePath ? cImagePath : MY_APPLET_SHARE_DATA_DIR"/locked.svg", cd_logoout_lock_screen, pMenu);  /// TODO: same question...
 	g_free (cImagePath);
 	if (myData.bCanStop)
 	{
@@ -801,6 +802,15 @@ static void cd_logout_switch_to_guest (void)
 		g_object_unref (pProxy);
 	}
 }
+
+static void cd_logoout_lock_screen (void)
+{
+	if (myConfig.cUserActionLock != NULL)
+		cairo_dock_launch_command (myConfig.cUserActionLock);
+	else
+		cairo_dock_fm_lock_screen ();
+}
+
 /*
 static gboolean cd_logout_switch_to_greeter (void)  // not really sure how to use it.
 {

--- a/logout/src/applet-struct.h
+++ b/logout/src/applet-struct.h
@@ -43,6 +43,7 @@ struct _AppletConfig {
 	gchar *cUserAction;  // custom logout command
 	gchar *cUserActionShutdown;  // custom shutdown command
 	gchar *cUserActionSwitchUser;  // custom switch-user command
+	gchar *cUserActionLock;  // custom screen lock command
 	CDActionsEnum iActionOnMiddleClick;
 	gint iShutdownTime;  // time_t
 	gchar *cEmblemPath;


### PR DESCRIPTION
- gnome / gvfs: handle screen locking on Wayland better (xdg-screensaver does not work, loginctl might)
- logout: allow to set a custom command for locking the screen
- Dbus: run launcher-API-daemon only if it can connect to Cairo-Dock (and exit with the dock)