### PR TITLE
Adapt plugins to core + small improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ include ("${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/GNUInstallDirs.cmake")
 ########### project ###############
 
 project ("cairo-dock-plugins")
-set (VERSION "3.5.99.beta7")
+set (VERSION "3.5.99.rc1")
 # can be different from VERSION, e.g. if a new version of plugins does not depend on things added to core
-set (CORE_REQUIRED_VERSION "3.5.99.beta6")
+set (CORE_REQUIRED_VERSION "3.5.99.rc1")
 
 add_definitions (-std=gnu99 -Wall -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Werror-implicit-function-declaration -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/Dbus/src/applet-dbus.c
+++ b/Dbus/src/applet-dbus.c
@@ -579,7 +579,7 @@ void cd_dbus_launch_service (void)
 	 */
 	#ifdef DBUSMENU_GTK_FOUND // need SetMenu => DBusMenu
 	if (myConfig.bLaunchLauncherAPIDaemon)
-		cairo_dock_launch_command (CD_PLUGINS_DIR"/cairo-dock-launcher-API-daemon");
+		cairo_dock_launch_command_single (CD_PLUGINS_DIR"/cairo-dock-launcher-API-daemon");
 	#endif
 }
 

--- a/Dbus/src/interface-applet-object.c
+++ b/Dbus/src/interface-applet-object.c
@@ -252,7 +252,7 @@ void cd_dbus_launch_applet_process (GldiModuleInstance *pModuleInstance, dbusApp
 		pModuleInstance->cConfFilePath, g_cCairoDockDataDir,
 		myData.cProgName, cPid, NULL};
 	cd_debug ("launching distant applet: %s/%s", cDirPath, cModuleName);
-	cairo_dock_launch_command_argv_full (args, cDirPath, FALSE);
+	cairo_dock_launch_command_argv_full (args, cDirPath, GLDI_LAUNCH_DEFAULT);
 	g_free (cExec);
 	g_free (cID);
 	g_free (cPid);

--- a/GMenu/src/applet-apps.c
+++ b/GMenu/src/applet-apps.c
@@ -61,7 +61,7 @@ static void _on_answer_launch_recent (int iClickedButton, GtkWidget *pInteractiv
 {
 	if (iClickedButton == 0 || iClickedButton == -1)  // ok ou entree.
 	{
-		GAppInfo *pAppInfo = NULL;
+		GDesktopAppInfo *pAppInfo = NULL;
 		if (pInteractiveWidget)  // find the selected one
 		{
 			int n = gtk_combo_box_get_active (GTK_COMBO_BOX (pInteractiveWidget));
@@ -72,11 +72,7 @@ static void _on_answer_launch_recent (int iClickedButton, GtkWidget *pInteractiv
 			pAppInfo = myData.pNewApps->data;
 		}
 		g_return_if_fail (pAppInfo != NULL);
-		// GdkAppLaunchContext will automatically use startup notify / xdg-activation,
-		// allowing e.g. the app to raise itself if necessary
-		GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
-		g_app_info_launch (pAppInfo, NULL, G_APP_LAUNCH_CONTEXT (context), NULL);
-		g_object_unref (context); // will be kept by GIO if necessary (and we don't care about the "launched" signal in this case)
+		cairo_dock_launch_app_info (pAppInfo);
 	}
 	
 	g_list_free (myData.pNewApps);  // the content elongs to pKnownApplications
@@ -106,7 +102,7 @@ void cd_menu_check_for_new_apps (void)
 			{
 				gtk_combo_box_text_append_text (
 					GTK_COMBO_BOX_TEXT (s_pNewAppsDialog->pInteractiveWidget),
-					g_app_info_get_name (a->data));
+					g_app_info_get_name (G_APP_INFO (a->data)));
 			}
 			gtk_combo_box_set_active (
 				GTK_COMBO_BOX (s_pNewAppsDialog->pInteractiveWidget), 0);
@@ -122,7 +118,7 @@ void cd_menu_check_for_new_apps (void)
 			{
 				gtk_combo_box_text_append_text (
 					GTK_COMBO_BOX_TEXT (pInteractiveWidget),
-					g_app_info_get_name (a->data));
+					g_app_info_get_name (G_APP_INFO (a->data)));
 			}
 
 			gtk_combo_box_set_active (GTK_COMBO_BOX (pInteractiveWidget), 0); // select the first one

--- a/GMenu/src/applet-notifications.c
+++ b/GMenu/src/applet-notifications.c
@@ -45,7 +45,7 @@ static void _cd_menu_configure_menu (GtkMenuItem *menu_item, gpointer data)
 {
 	CD_APPLET_ENTER;
 	if (myConfig.cConfigureMenuCommand != NULL)
-		cairo_dock_launch_command (myConfig.cConfigureMenuCommand);
+		cairo_dock_launch_command_full (myConfig.cConfigureMenuCommand, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 	else if (s_cEditMenuCmd != NULL)
 		cairo_dock_launch_command_single_gui (s_cEditMenuCmd);
 	CD_APPLET_LEAVE();

--- a/GMenu/src/applet-run-dialog.c
+++ b/GMenu/src/applet-run-dialog.c
@@ -343,7 +343,7 @@ static void _cd_menu_on_quick_launch (int iClickedButton, GtkWidget *pInteractiv
 	{
 		const gchar *cCommand = gtk_entry_get_text (GTK_ENTRY (pInteractiveWidget));
 		if (cCommand != NULL && *cCommand != '\0')
-			cairo_dock_launch_command (cCommand);
+			cairo_dock_launch_command_full (cCommand, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 	}
 	else
 	{

--- a/GMenu/src/applet-struct.h
+++ b/GMenu/src/applet-struct.h
@@ -61,10 +61,10 @@ struct _AppletData {
 	// new apps
 	gboolean bFirstLaunch;
 	GHashTable *pKnownApplications;  // table of all applications that could go in the menu, including ignored ones
-	GList *pNewApps;  // a list of GAppInfo that were not present before.
+	GList *pNewApps;  // a list of GDesktopAppInfo that were not present before.
 	// entry
 	GtkWidget *pEntry;
-	GSList *pApps; // a (singly linked) list of GAppInfo: better to check all items
+	GSList *pApps; // a (singly linked) list of GDesktopAppInfo: better to check all items
 	// recent files sub-menu
 	GtkWidget *pRecentMenuItem;
 	gint iNbRecentItems;

--- a/GMenu/src/applet-tree.c
+++ b/GMenu/src/applet-tree.c
@@ -44,12 +44,8 @@ static void _on_tree_changed (GMenuTree *tree, G_GNUC_UNUSED gpointer data)
 
 static void _on_activate_entry (GtkWidget *menuitem, GMenuTreeEntry *entry)
 {
-	// GdkAppLaunchContext will automatically use startup notify / xdg-activation,
-	// allowing e.g. the app to raise itself if necessary
-	GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
 	GDesktopAppInfo *pAppInfo = gmenu_tree_entry_get_app_info (entry);
-	g_app_info_launch (G_APP_INFO (pAppInfo), NULL, G_APP_LAUNCH_CONTEXT (context), NULL);
-	g_object_unref (context); // will be kept by GIO if necessary (and we don't care about the "launched" signal in this case)
+	cairo_dock_launch_app_info (pAppInfo);
 }
 
 static void _on_drag_data_get (GtkWidget *widget,

--- a/RSSreader/src/applet-notifications.c
+++ b/RSSreader/src/applet-notifications.c
@@ -112,7 +112,10 @@ CD_APPLET_ON_DROP_DATA_END
 static void _start_browser (GtkMenuItem *menu_item, GldiModuleInstance *myApplet)
 {
 	if (myConfig.cSpecificWebBrowser != NULL)  // une commande specifique est fournie.
-		cairo_dock_launch_command_printf ("%s %s", NULL, myConfig.cSpecificWebBrowser, myConfig.cUrl);
+	{
+		const gchar * const args[] = {myConfig.cSpecificWebBrowser, myConfig.cUrl, NULL};
+		cairo_dock_launch_command_argv_full (args, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
+	}
 	else  // sinon on utilise la commande par defaut.
 		cairo_dock_fm_launch_uri (myConfig.cUrl);
 }

--- a/Recent-Events/src/applet-notifications.c
+++ b/Recent-Events/src/applet-notifications.c
@@ -190,9 +190,9 @@ CD_APPLET_ON_BUILD_MENU_PROTO
 			
 			CD_APPLET_ADD_IN_MENU_WITH_STOCK_AND_DATA (D_("Delete all events"), GLDI_ICON_NAME_DELETE, _clear_all_events, CD_APPLET_MY_MENU, myApplet);
 		}
-		else if (CD_APPLET_CLICKED_ICON->pClassApp != NULL)
+		else if (CD_APPLET_CLICKED_ICON->pAppInfo && CD_APPLET_CLICKED_ICON->pAppInfo->app)
 		{
-			GDesktopAppInfo *app = CD_APPLET_CLICKED_ICON->pClassApp;
+			GDesktopAppInfo *app = CD_APPLET_CLICKED_ICON->pAppInfo->app;
 			const gchar **types = app ? g_app_info_get_supported_types (G_APP_INFO (app)) : NULL;
 			if (types)
 			{

--- a/Scooby-Do/src/applet-appli-finder.c
+++ b/Scooby-Do/src/applet-appli-finder.c
@@ -173,7 +173,7 @@ static gboolean _load_applis_buffer_idle (gpointer data)
 	}
 	int iNbAppliLoaded = 0;
 	Icon *pIcon;
-	gint iDesiredIconSize = 10; // cairo_dock_search_icon_size (GTK_ICON_SIZE_MENU); // 16px (was 48px but why?) // to data?
+	gint iDesiredIconSize = 64; // was 10px which is too small cairo_dock_search_icon_size (GTK_ICON_SIZE_MENU); // 16px (was 48px but why?) // to data?
 	GList *a;
 	for (a = myData.pCurrentApplicationToLoad; a != NULL && iNbAppliLoaded < 3; a = a->next)  // on en charge 3 d'un coup.
 	{

--- a/Scooby-Do/src/applet-appli-finder.c
+++ b/Scooby-Do/src/applet-appli-finder.c
@@ -125,6 +125,7 @@ static void _browse_dir (const gchar *cDirPath)
 				g_free (cPath);
 				continue;
 			}
+			//!! TODO: set pCustomLauncher (or pAppInfo?) instead
 			pIcon = cairo_dock_create_dummy_launcher (NULL,
 				cIconName,
 				cCommand,
@@ -135,7 +136,7 @@ static void _browse_dir (const gchar *cDirPath)
 			if (str != NULL)
 				*str = '\0';
 			cd_debug (" + %s", pIcon->cCommand);
-			pIcon->cWorkingDirectory = g_key_file_get_string (pKeyFile, "Desktop Entry", "Path", NULL);
+			// pIcon->cWorkingDirectory = g_key_file_get_string (pKeyFile, "Desktop Entry", "Path", NULL);
 			myData.pApplications = g_list_prepend (myData.pApplications, pIcon);
 			g_key_file_free (pKeyFile);
 			if (! bFoundOneAppli)

--- a/Scooby-Do/src/applet-draw.c
+++ b/Scooby-Do/src/applet-draw.c
@@ -144,7 +144,7 @@ void cd_do_render_cairo (CairoDock *pMainDock, cairo_t *pCairoContext)
 			
 			double fIconScale = (iIconsWidth > pMainDock->container.iWidth ? (double) pMainDock->container.iWidth / iIconsWidth : 1.);
 			double x0 = (pMainDock->container.iWidth - iIconsWidth * fIconScale) / 2;
-			double x = x0 + iOffsetX * fIconScale;  // abscisse de l'icone courante.
+			double x = x0 - iOffsetX * fIconScale;  // abscisse de l'icone courante.
 			Icon *pIcon;
 			int iWidth, iHeight;
 			double fZoom;
@@ -162,7 +162,7 @@ void cd_do_render_cairo (CairoDock *pMainDock, cairo_t *pCairoContext)
 				{
 					if (x < x0)
 						x += iIconsWidth * fIconScale;
-					else if (x > x0 + iIconsWidth * fIconScale)
+					else if (x - (iNbIcons & 1 ? iWidth * fZoom * fIconScale / 2 : 0.) >= x0 + iIconsWidth * fIconScale)
 						x -= iIconsWidth * fIconScale;
 				}
 				if (pMainDock->container.bIsHorizontal)
@@ -293,14 +293,12 @@ void cd_do_render_opengl (CairoDock *pMainDock)
 			double fFrameHeight = pMainDock->container.iHeight/2;
 			double fRadius = fFrameHeight / 10;
 			double fLineWidth = 0.;
-			double fDockOffsetX, fDockOffsetY;  // Offset du coin haut gauche du cadre.
-			fDockOffsetX = pMainDock->container.iWidth/2 - fFrameWidth / 2 - fRadius;
-			fDockOffsetY = (!myConfig.bTextOnTop ? pMainDock->container.iHeight : fFrameHeight);
+			double fDockOffsetY = fFrameHeight * (myConfig.bTextOnTop ? 0.5 : 1.5);
 			double fFrameColor[4] = {myConfig.pFrameColor[0], myConfig.pFrameColor[1], myConfig.pFrameColor[2], myConfig.pFrameColor[3] * fAlpha};
 			glPushMatrix ();
 			if (! pMainDock->container.bIsHorizontal)
 				glRotatef (pMainDock->container.bDirectionUp ? 90. : -90., 0., 0., 1.);
-			glTranslatef (fDockOffsetX, fDockOffsetY, 0.);
+			glTranslatef (pMainDock->container.iWidth / 2.0, fDockOffsetY, 0.0);
 			cairo_dock_draw_rounded_rectangle_opengl (fFrameWidth, fFrameHeight, fRadius, fLineWidth, fFrameColor);
 			glPopMatrix ();
 			
@@ -363,7 +361,6 @@ void cd_do_render_opengl (CairoDock *pMainDock)
 					_cairo_dock_disable_texture ();
 					fLineWidth = 4.;
 					double fFrameColor[4] = {myConfig.pFrameColor[0]+.1, myConfig.pFrameColor[1]+.1, myConfig.pFrameColor[2]+.1, 1.};
-					glTranslatef (iWidth/2 * fZoom * fIconScale + fLineWidth/2, iHeight * fZoom/2 * fIconScale - fLineWidth/2, 0.);
 					cairo_dock_draw_rounded_rectangle_opengl (iWidth * fZoom * fIconScale - fLineWidth,
 						iHeight * fZoom * fIconScale - fLineWidth,
 						fRadius,
@@ -387,8 +384,8 @@ void cd_do_render_opengl (CairoDock *pMainDock)
 		double fRadius = myDocksParam.iDockRadius * myConfig.fFontSizeRatio;
 		
 		double fDockOffsetX, fDockOffsetY;  // Offset du coin haut gauche du cadre.
-		fDockOffsetX = pMainDock->container.iWidth/2 - fFrameWidth * fTextScale / 2 - fRadius;
-		fDockOffsetY = (myConfig.bTextOnTop ? pMainDock->container.iHeight : fFrameHeight);
+		fDockOffsetX = pMainDock->container.iWidth/2;
+		fDockOffsetY = (myConfig.bTextOnTop ? pMainDock->container.iHeight : fFrameHeight) - 0.5 * fFrameHeight;
 		
 		glPushMatrix ();
 		double fFrameColor[4] = {myConfig.pFrameColor[0], myConfig.pFrameColor[1], myConfig.pFrameColor[2], myConfig.pFrameColor[3] * fAlpha};

--- a/Scooby-Do/src/applet-listing.c
+++ b/Scooby-Do/src/applet-listing.c
@@ -93,9 +93,11 @@ static gboolean on_expose_listing (GtkWidget *pWidget, cairo_t *ctx, CDListing *
 		gldi_glx_end_draw_container (CAIRO_CONTAINER (pListing));
 	}
 	else*/
-	{
-		gldi_object_notify (CAIRO_CONTAINER (pListing), NOTIFICATION_RENDER, pListing, ctx);
-	}
+	
+	// if (g_bUseOpenGL) gldi_gl_container_begin_draw (CAIRO_CONTAINER (pListing));
+	gldi_object_notify (CAIRO_CONTAINER (pListing), NOTIFICATION_RENDER, pListing, ctx);
+	// if (g_bUseOpenGL) gldi_gl_container_end_draw (CAIRO_CONTAINER (pListing));
+	
 	return FALSE;
 }
 static gboolean on_configure_listing (GtkWidget* pWidget, GdkEventConfigure* pEvent, CDListing *pListing)
@@ -121,16 +123,15 @@ static gboolean on_configure_listing (GtkWidget* pWidget, GdkEventConfigure* pEv
 		pListing->container.iWidth = iNewWidth;
 		pListing->container.iHeight = iNewHeight;
 		
-		/*if (g_bUseOpenGL && pListing->container.glContext)
+/*		if (g_bUseOpenGL && pListing->container.glContext)
 		{
-			GLsizei w = pEvent->width;
-			GLsizei h = pEvent->height;
-			if (! gldi_gl_container_begin_draw (CAIRO_CONTAINER (pListing)))
+			gldi_gl_container_resized (CAIRO_CONTAINER (pListing), pEvent->width, pEvent->height);
+			
+			if (! gldi_gl_container_make_current (CAIRO_CONTAINER (pListing)))
 				return FALSE;
-			
-			glViewport(0, 0, w, h);
-			
-			cairo_dock_set_ortho_view (CAIRO_CONTAINER (pListing));
+
+			// gldi_gl_container_set_perspective_view (CAIRO_CONTAINER (pListing));
+			gldi_gl_container_set_ortho_view (CAIRO_CONTAINER (pListing));
 		}*/
 	}
 	return FALSE;
@@ -178,6 +179,7 @@ CDListing *cd_do_create_listing (void)
 	CDListing *pListing = g_new0 (CDListing, 1);
 	GldiContainerAttr attr;
 	memset (&attr, 0, sizeof (GldiContainerAttr));
+	attr.bNoOpengl = TRUE; // does not work yet
 	gldi_object_init (GLDI_OBJECT(pListing), &myContainerObjectMgr, &attr);
 	
 	/*pListing->container.iType = CAIRO_DOCK_NB_CONTAINER_TYPES+1;

--- a/Scooby-Do/src/applet-notifications.c
+++ b/Scooby-Do/src/applet-notifications.c
@@ -237,7 +237,7 @@ gboolean cd_do_key_pressed (gpointer pUserData, GldiContainer *pContainer, guint
 		if (myData.pMatchingIcons != NULL)  // on a une appli a lancer.
 		{
 			Icon *pIcon = (myData.pCurrentMatchingElement ? myData.pCurrentMatchingElement->data : myData.pMatchingIcons->data);
-			cairo_dock_launch_command (pIcon->cCommand);
+			cairo_dock_launch_command_full (pIcon->cCommand, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 		}
 		else if (myData.pListing && myData.pListing->pCurrentEntry)  // pas d'appli mais une entree => on l'execute.
 		{
@@ -251,7 +251,7 @@ gboolean cd_do_key_pressed (gpointer pUserData, GldiContainer *pContainer, guint
 		else if (myData.iNbValidCaracters > 0)  // pas d'entree mais du texte => on l'execute tel quel.
 		{
 			cd_debug ("on execute '%s'", myData.sCurrentText->str);
-			cairo_dock_launch_command (myData.sCurrentText->str);
+			cairo_dock_launch_command_full (myData.sCurrentText->str, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 		}
 		
 		if (!(iModifierType & GDK_CONTROL_MASK) && !(iModifierType & GDK_MOD1_MASK) && !(iModifierType & GDK_SHIFT_MASK))

--- a/Status-Notifier/src/applet-host.c
+++ b/Status-Notifier/src/applet-host.c
@@ -206,7 +206,7 @@ void cd_satus_notifier_launch_our_watcher (void)
 	if (myData.bNoIAS && myData.bNoWatcher)
 	{
 		cd_message ("starting our own watcher...");
-		cairo_dock_launch_command (CD_PLUGINS_DIR"/status-notifier-watcher");
+		cairo_dock_launch_command_single (CD_PLUGINS_DIR"/status-notifier-watcher");
 	}
 }
 

--- a/Status-Notifier/src/applet-notifications.c
+++ b/Status-Notifier/src/applet-notifications.c
@@ -128,7 +128,7 @@ CD_APPLET_ON_CLICK_BEGIN
 				if (pItem->cId != NULL)
 				{
 					/// TODO: try to get the icon in the taskbar, because launch the command doesn't raise the window if it was already visible (but it does pop up it if it was hidden, usually).
-					cairo_dock_launch_command (pItem->cId);  // try to launch the application because generally this click shows its item's window.
+					cairo_dock_launch_command_full (pItem->cId, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);  // try to launch the application because generally this click shows its item's window.
 				}
 			}
 		}

--- a/gnome-integration/src/applet-utils.c
+++ b/gnome-integration/src/applet-utils.c
@@ -31,7 +31,7 @@ void env_backend_logout (void)
 	if (cResult != NULL && *cResult == '/')
 	{
 		args[2] = "--logout";
-		cairo_dock_launch_command_argv_full (args + 1, NULL, TRUE); // i.e. gnome-session-quit --logout
+		cairo_dock_launch_command_argv_full (args + 1, NULL, GLDI_LAUNCH_GUI); // i.e. gnome-session-quit --logout
 	}
 	else
 	{
@@ -42,14 +42,14 @@ void env_backend_logout (void)
 		if (cResult != NULL && *cResult == '/')
 		{
 			args[2] = "--logout";
-			cairo_dock_launch_command_argv_full (args + 1, NULL, TRUE);
+			cairo_dock_launch_command_argv_full (args + 1, NULL, GLDI_LAUNCH_GUI);
 		}
 		else
 		{
 			args[0] = "gnome-session-save";
 			args[1] = "--kill";
 			args[2] = "--gui";
-			cairo_dock_launch_command_argv_full (args, NULL, TRUE);
+			cairo_dock_launch_command_argv_full (args, NULL, GLDI_LAUNCH_GUI);
 		}
 	}
 	g_free (cResult);
@@ -63,7 +63,7 @@ void env_backend_shutdown (void)
 	if (cResult != NULL && *cResult == '/')
 	{
 		args[2] = "--power-off";
-		cairo_dock_launch_command_argv_full (args + 1, NULL, TRUE); // i.e. gnome-session-quit --logout
+		cairo_dock_launch_command_argv_full (args + 1, NULL, GLDI_LAUNCH_GUI); // i.e. gnome-session-quit --power-off
 	}
 	else
 	{
@@ -74,13 +74,13 @@ void env_backend_shutdown (void)
 		if (cResult != NULL && *cResult == '/')
 		{
 			args[2] = "--power-off";
-			cairo_dock_launch_command_argv_full (args + 1, NULL, TRUE);
+			cairo_dock_launch_command_argv_full (args + 1, NULL, GLDI_LAUNCH_GUI);
 		}
 		else
 		{
 			args[0] = "gnome-session-save";
 			args[1] = "--shutdown-dialog";
-			cairo_dock_launch_command_argv_full (args, NULL, TRUE);
+			cairo_dock_launch_command_argv_full (args, NULL, GLDI_LAUNCH_GUI);
 		}
 	}
 	g_free (cResult);
@@ -120,14 +120,13 @@ void env_backend_setup_time (void)
 		g_free (cResult);
 	}
 	if (args[0])
-		cairo_dock_launch_command_argv_full (args, NULL, TRUE);
+		cairo_dock_launch_command_argv_full (args, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 	else
 		cd_warning ("couldn't guess what program to use to setup the time and date.");
 }
 
 void env_backend_show_system_monitor (void)
 {
-	const gchar * const args[] = {"gnome-system-monitor", NULL};
-	cairo_dock_launch_command_argv_full (args, NULL, TRUE);
+	cairo_dock_launch_command_single_gui ("gnome-system-monitor");
 }
 

--- a/gvfs-integration/cairo-dock-gio-vfs.c
+++ b/gvfs-integration/cairo-dock-gio-vfs.c
@@ -705,64 +705,71 @@ static void cairo_dock_gio_vfs_launch_uri (const gchar *cURI)
 	
 	gchar *cTargetURI = _cd_find_target_uri (cValidUri);
 	cURI= (cTargetURI ? cTargetURI : cValidUri);
+	GList *pURIList = g_list_append (NULL, (gpointer)cURI);
 	
+	gchar *cURIScheme = g_uri_parse_scheme (cURI);
 	// now, try to launch it with the default program know by gvfs.
-	GdkAppLaunchContext *context = gdk_display_get_app_launch_context (gdk_display_get_default ());
-	gboolean bSuccess = g_app_info_launch_default_for_uri (cURI,
-		G_APP_LAUNCH_CONTEXT (context),
-		&erreur);
-	g_object_unref (context);
-	if (erreur != NULL || ! bSuccess)  // error can happen (for instance, opening 'trash:/' on XFCE with a previous installation of nautilus) => try with another method.
+	GAppInfo *pAppDefault = NULL;
+	gboolean bSuccess = FALSE;
+	if (cURIScheme && *cURIScheme)
+		pAppDefault = g_app_info_get_default_for_uri_scheme (cURIScheme);
+	g_free (cURIScheme);
+	
+	if (pAppDefault)
 	{
-		cd_debug ("gvfs-integration : couldn't launch '%s' [%s]", cURI, erreur->message);
-		g_error_free (erreur);
-		erreur = NULL;
-		
-		// get the mime-type.
-		gboolean bIsURI = (*cURI != '/');
-		GFile *pFile = (bIsURI ? g_file_new_for_uri (cURI) : g_file_new_for_path (cURI));
-		const gchar *cQuery = G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE;
-		GFileInfo *pFileInfo = g_file_query_info (pFile,
-			cQuery,
-			G_FILE_QUERY_INFO_NONE,
-			NULL,
-			&erreur);
-		if (erreur != NULL)  // if no mime-type (can happen with not mounted volumes), abort.
-		{
-			cd_warning ("gvfs-integration : %s", erreur->message);
-			g_error_free (erreur);
-		}
-		else
-		{
-			// get all the apps that can launch it.
-			const gchar *cMimeType = g_file_info_get_content_type (pFileInfo);
-			GList *pAppsList = g_app_info_get_all_for_type (cMimeType);
-			GAppInfo *pAppInfo;
-			GList *a;
-			for (a = pAppsList; a != NULL; a = a->next)
-			{
-				pAppInfo = a->data;
-				GList *list = NULL;
-				context = gdk_display_get_app_launch_context (gdk_display_get_default ());
-				if (g_app_info_supports_uris (pAppInfo) && bIsURI)
-				{
-					list = g_list_append (list, (gpointer)cURI);
-					g_app_info_launch_uris (pAppInfo, list, G_APP_LAUNCH_CONTEXT (context), NULL);
-					
-				}
-				else
-				{
-					list = g_list_append (list, pFile);
-					g_app_info_launch (pAppInfo, list, G_APP_LAUNCH_CONTEXT (context), NULL);
-				}
-				g_object_unref (context);
-				g_list_free (list);
-				break;
-			}
-			g_list_free (pAppsList);
-		}
-		g_object_unref (pFile);
+		GDesktopAppInfo *app = G_DESKTOP_APP_INFO (pAppDefault);
+		if (app) bSuccess = cairo_dock_launch_app_info_with_uris (app, pURIList);
+		g_object_unref (pAppDefault);
+		if (bSuccess) goto launch_uri_end;
 	}
+	
+	// get the mime-type.
+	GFile *pFile = ((*cURI != '/') ? g_file_new_for_uri (cURI) : g_file_new_for_path (cURI));
+	const gchar *cQuery = G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE;
+	GFileInfo *pFileInfo = g_file_query_info (pFile,
+		cQuery,
+		G_FILE_QUERY_INFO_NONE,
+		NULL,
+		&erreur);
+	if (erreur != NULL)  // if no mime-type (can happen with not mounted volumes), abort.
+	{
+		cd_warning ("gvfs-integration : %s", erreur->message);
+		g_error_free (erreur);
+		g_object_unref (pFile);
+		goto launch_uri_end;
+	}
+	const gchar *cMimeType = g_file_info_get_content_type (pFileInfo);
+	
+	pAppDefault = g_app_info_get_default_for_type (cMimeType, FALSE);
+	if (pAppDefault)
+	{
+		GDesktopAppInfo *app = G_DESKTOP_APP_INFO (pAppDefault);
+		if (app) bSuccess = cairo_dock_launch_app_info_with_uris (app, pURIList);
+		g_object_unref (pAppDefault);
+	}
+	
+	if (! bSuccess)  // error can happen (for instance, opening 'trash:/' on XFCE with a previous installation of nautilus) => try with another method.
+	{
+		cd_debug ("gvfs-integration : couldn't launch '%s' with its default app", cURI);
+		
+		GList *pAppsList = g_app_info_get_all_for_type (cMimeType);
+		GAppInfo *pAppInfo;
+		GDesktopAppInfo *app;
+		GList *a;
+		for (a = pAppsList; a != NULL; a = a->next)
+		{
+			pAppInfo = a->data;
+			app = G_DESKTOP_APP_INFO (pAppInfo);
+			if (app) bSuccess = cairo_dock_launch_app_info_with_uris (app, pURIList);
+			if (bSuccess) break;
+		}
+		g_list_free_full (pAppsList, g_object_unref);
+	}
+	g_object_unref (pFileInfo);
+	g_object_unref (pFile);
+
+launch_uri_end:
+	g_list_free (pURIList);
 	g_free (cValidUri);
 	g_free (cTargetURI);
 }
@@ -1548,6 +1555,7 @@ static void cairo_dock_gio_vfs_lock_screen (void) {
 		// we use loginctl and hope it works
 		args[0] = "loginctl";
 		args[1] = "lock-session";
+		// will be transient (basically just calls the DBus method, we could do it ourselves as well)
 		cairo_dock_launch_command_argv (args);
 	}
 	else
@@ -1559,7 +1567,7 @@ static void cairo_dock_gio_vfs_lock_screen (void) {
 		{
 			args[0] = "xdg-screensaver";
 			args[1] = "lock";
-			cairo_dock_launch_command_argv (args);
+			cairo_dock_launch_command_argv_full (args, NULL, GLDI_LAUNCH_SLICE);
 		}
 		g_free (cResult);
 	}

--- a/kde-integration/src/applet-utils.c
+++ b/kde-integration/src/applet-utils.c
@@ -67,19 +67,20 @@ void env_backend_reboot (void)
 void env_backend_lock_screen (void)
 {
 	const char * const args[] = {"qdbus", "org.freedesktop.ScreenSaver", "/ScreenSaver", "Lock", NULL};
-	cairo_dock_launch_command_argv_full (args, NULL, TRUE);
+	cairo_dock_launch_command_argv (args);
 }
 
 void env_backend_setup_time (void)
 {
-	char *kcmshell = g_strdup_printf ("kcmshell%d clock", get_kde_version());
+	char *kcmshell = g_strdup_printf ("kcmshell%d", get_kde_version());
 	const char * const args[] = {kcmshell, "clock", NULL};
-	cairo_dock_launch_command_argv_full (args, NULL, TRUE);
+	cairo_dock_launch_command_argv_full (args, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
+	g_free (kcmshell);
 }
 
 void env_backend_show_system_monitor (void)
 {
-	cairo_dock_launch_command_single_gui ("ksysguard");
+	cairo_dock_launch_command_single_gui ("plasma-systemmonitor");
 }
 
 int get_kde_version (void)

--- a/kde-integration/src/applet-vfs.c
+++ b/kde-integration/src/applet-vfs.c
@@ -42,7 +42,7 @@ void vfs_backend_launch_uri (const gchar *cURI)
 
 	cd_debug ("%s (%s)", __func__, cURI);
 	const gchar * const args[] = {_get_kioclient (), "exec", cURI, NULL};
-	cairo_dock_launch_command_argv_full (args, NULL, TRUE);
+	cairo_dock_launch_command_argv_full (args, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 
 	/// tester ca :
 	//KURL url(cURI);

--- a/logout/src/applet-logout.c
+++ b/logout/src/applet-logout.c
@@ -716,6 +716,7 @@ static void cd_logout_switch_to_user (const gchar *cUser)
 {
 	const gchar *seat = g_getenv ("XDG_SEAT_PATH");
 	GError *error = NULL;
+	gboolean bSuccess = FALSE;
 	if (seat)  // else, we could possibly get it by: ck -> GetCurrentSession -> session -> GetSeatId
 	{
 		DBusGProxy *pProxy = cairo_dock_create_new_system_proxy (
@@ -731,10 +732,8 @@ static void cd_logout_switch_to_user (const gchar *cUser)
 		{
 			cd_warning ("DisplayManager (LocalDisplay) error: %s", error->message);
 			g_error_free (error);
-			if (myConfig.cUserActionSwitchUser != NULL)
-				cairo_dock_launch_command_printf ("%s %s", NULL,
-					myConfig.cUserActionSwitchUser, cUser);
 		}
+		else bSuccess = TRUE;
 		g_object_unref (pProxy);
 	}
 	else // try with gdm
@@ -751,11 +750,15 @@ static void cd_logout_switch_to_user (const gchar *cUser)
 		{
 			cd_warning ("DisplayManager error: %s", error->message);
 			g_error_free (error);
-			if (myConfig.cUserActionSwitchUser != NULL)
-				cairo_dock_launch_command_printf ("%s %s", NULL,
-					myConfig.cUserActionSwitchUser, cUser);
 		}
+		else bSuccess = TRUE;
 		g_object_unref (pProxy);
+	}
+	
+	if (!bSuccess && myConfig.cUserActionSwitchUser)
+	{
+		const gchar * const args[] = {myConfig.cUserActionSwitchUser, cUser, NULL};
+		cairo_dock_launch_command_argv (args);
 	}
 }
 

--- a/netspeed/src/applet-notifications.c
+++ b/netspeed/src/applet-notifications.c
@@ -94,7 +94,7 @@ static void _show_system_monitor (GtkMenuItem *menu_item, GldiModuleInstance *my
 {
 	if (myConfig.cSystemMonitorCommand != NULL)
 	{
-		cairo_dock_launch_command (myConfig.cSystemMonitorCommand);
+		cairo_dock_launch_command_full (myConfig.cSystemMonitorCommand, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 	}
 	else
 	{

--- a/shortcuts/src/applet-notifications.c
+++ b/shortcuts/src/applet-notifications.c
@@ -276,23 +276,6 @@ static void _open_home_dir (GtkMenuItem *menu_item, gpointer data)
 	cairo_dock_fm_launch_uri (g_getenv ("HOME"));
 }
 
-static gboolean s_bNCSChecked = FALSE;
-static gboolean s_bNCSAvailable = FALSE;
-
-static void _check_ncs (void)
-{
-	gchar *cResult = cairo_dock_launch_command_sync ("which nautilus-connect-server");
-	if (cResult != NULL && *cResult == '/')
-		s_bNCSAvailable = TRUE;
-	g_free (cResult);
-	s_bNCSChecked = TRUE;
-}
-
-static void _open_ncs (G_GNUC_UNUSED GtkMenuItem *menu_item, G_GNUC_UNUSED gpointer data)
-{
-	cairo_dock_launch_command ("nautilus-connect-server");
-}
-
 static void _open_network (G_GNUC_UNUSED GtkMenuItem *menu_item, G_GNUC_UNUSED gpointer data)
 {
 	cairo_dock_fm_launch_uri ("network:///");
@@ -321,13 +304,6 @@ CD_APPLET_ON_BUILD_MENU_BEGIN
 		gchar *cLabel = g_strdup_printf ("%s (%s)", D_("Open Home directory"), D_("middle-click"));
 		CD_APPLET_ADD_IN_MENU_WITH_STOCK (cLabel, GLDI_ICON_NAME_OPEN, _open_home_dir, CD_APPLET_MY_MENU);
 		g_free (cLabel);
-
-		// Connect to servers (ftp, ssh, samba, etc.)
-		if (! s_bNCSChecked)
-			_check_ncs ();
-		if (s_bNCSAvailable)
-			CD_APPLET_ADD_IN_MENU_WITH_STOCK (D_("Connect to Server..."),
-				GLDI_ICON_NAME_OPEN, _open_ncs, CD_APPLET_MY_MENU);
 
 		// browse network (e.g.: samba)
 		CD_APPLET_ADD_IN_MENU_WITH_STOCK (D_("Browse Network"), GLDI_ICON_NAME_OPEN,

--- a/shortcuts/src/applet-notifications.c
+++ b/shortcuts/src/applet-notifications.c
@@ -132,7 +132,7 @@ CD_APPLET_ON_CLICK_BEGIN
 		{
 			// Click on a bookmark which contains a custom cmd, e.g.: "nautilus x-nautilus-(...)
 			if (CD_APPLET_CLICKED_ICON->iVolumeID == CD_VOLUME_ID_BOOKMARK_CMD)
-				cairo_dock_launch_command (CD_APPLET_CLICKED_ICON->cCommand);
+				cairo_dock_launch_command_full (CD_APPLET_CLICKED_ICON->cCommand, NULL, GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE);
 			else
 			{
 				/* check if it's a mounted URI


### PR DESCRIPTION
Use the new APIs for launching apps and commands in the most important places.
Additional small improvements:
 - Scooby-do: fix some rendering issues
 - Global-Menu: support Qt apps on KWin Wayland
 - Remote-Control: enable on Wayfire, use the toggle_menu signal to start it