### PR TITLE
Fix missing icons in GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include (GNUInstallDirs)
 
 set (VERSION "3.5.99.rc4")
 # can be different from VERSION, e.g. if a new version of plugins does not depend on things added to core
-set (CORE_REQUIRED_VERSION "3.5.99.rc5")
+set (CORE_REQUIRED_VERSION "3.5.99.rc6")
 
 add_definitions (-std=gnu99 -Wall -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Werror-implicit-function-declaration -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ pkg_get_variable(prefix             gldi plugins_prefix)
 pkg_get_variable(localedir          gldi plugins_locale)
 pkg_get_variable(gettext_domain     gldi plugins_gettext)
 pkg_get_variable(gtkversion         gldi gtkversion)
+pkg_get_variable(pkgdatadir         gldi pkgdatadir)
 
 # check that installation dir matches with the core
 if (NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "${prefix}")


### PR DESCRIPTION
The `pkgdatadir` variable from core is required for properly displaying some icons in the settings GUI.