### PR TITLE
dock-rendering: round up in dock size calculations

### DIFF
--- a/dock-rendering/src/rendering-3D-plane.c
+++ b/dock-rendering/src/rendering-3D-plane.c
@@ -49,7 +49,7 @@ static void cd_rendering_calculate_max_dock_size_3D_plane (CairoDock *pDock)
 	
 	_define_parameters (hi, h0, H, l, r, gamma, h, w, dw);
 	double h0max = (1 + myIconsParam.fAmplitude) * pDock->iMaxIconHeight * pDock->container.fRatio + MAX ((pDock->container.bIsHorizontal ? myIconsParam.iLabelSize : 0), myDocksParam.iFrameMargin + l);
-	pDock->iMaxDockHeight = (int) (hi + h0max + l);
+	pDock->iMaxDockHeight = (int) ceil (hi + h0max + l);
 	
 	// 1ere estimation.
 	// w

--- a/dock-rendering/src/rendering-curve.c
+++ b/dock-rendering/src/rendering-curve.c
@@ -113,7 +113,7 @@ static void cd_rendering_calculate_max_dock_size_curve (CairoDock *pDock)
 	
 	pDock->iDecorationsHeight = myDocksParam.iFrameMargin + my_iCurveAmplitude + .5 * pDock->iMaxIconHeight;  // de bas en haut.
 	
-	pDock->iMaxDockHeight = iDockLineWidth + myDocksParam.iFrameMargin + my_iCurveAmplitude + (1 + myIconsParam.fAmplitude) * pDock->iMaxIconHeight * pDock->container.fRatio + (pDock->container.bIsHorizontal ? myIconsParam.iLabelSize : 0);  // de bas en haut.
+	pDock->iMaxDockHeight = iDockLineWidth + myDocksParam.iFrameMargin + my_iCurveAmplitude + ceil ((1 + myIconsParam.fAmplitude) * pDock->iMaxIconHeight * pDock->container.fRatio) + (pDock->container.bIsHorizontal ? myIconsParam.iLabelSize : 0);  // de bas en haut.
 	
 	double fRatio = (pDock->iRefCount == 0 && pDock->iVisibility == CAIRO_DOCK_VISI_RESERVE ? 1. : pDock->container.fRatio);  // prevent the dock from resizing itself and all the maximized windows each time an icon is removed/inserted.
 	pDock->iMinDockHeight = iDockLineWidth + myDocksParam.iFrameMargin + my_iCurveAmplitude + pDock->iMaxIconHeight * fRatio;  // de bas en haut.


### PR DESCRIPTION
This is to avoid docks being 1 pixel smaller than need to be and cutting off the top of labels.