### PR TITLE
Recent-Events: fix missing pointer cast

### DIFF
--- a/Recent-Events/src/applet-notifications.c
+++ b/Recent-Events/src/applet-notifications.c
@@ -156,7 +156,7 @@ static void _on_find_related_events (ZeitgeistResultSet *pEvents, Icon *pIcon)
 			
 			struct _OpenFileData *data = g_new0 (struct _OpenFileData, 1);
 			data->app = pIcon->pAppInfo; // note: if we got here, pIcon->pAppInfo != NULL
-			gldi_object_ref (data->app);
+			gldi_object_ref (GLDI_OBJECT (data->app));
 			data->cURI = g_strdup (cEventURI);
 			g_free (cPath);
 			


### PR DESCRIPTION
Should fix failing package build on Ubuntu 25.04