### PR TITLE
Smooth scrolling support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.5.99.rc8")
+set (VERSION "3.5.99.rc9")
 # can be different from VERSION, e.g. if a new version of plugins does not depend on things added to core
-set (CORE_REQUIRED_VERSION "3.5.99.rca")
+set (CORE_REQUIRED_VERSION "3.5.99.rcb")
 
 add_definitions (-std=gnu99 -Wall -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Werror-implicit-function-declaration -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/Dbus/src/interface-applet-signals.c
+++ b/Dbus/src/interface-applet-signals.c
@@ -332,7 +332,7 @@ gboolean cd_dbus_applet_emit_on_middle_click_icon (gpointer data, Icon *pClicked
 	return GLDI_NOTIFICATION_INTERCEPT;
 }
 
-gboolean cd_dbus_applet_emit_on_scroll_icon (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer, int iDirection)
+gboolean cd_dbus_applet_emit_on_scroll_icon (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer, int iDirection, gboolean)
 {
 	if (pClickedIcon == NULL)
 		return GLDI_NOTIFICATION_LET_PASS;

--- a/Dbus/src/interface-applet-signals.h
+++ b/Dbus/src/interface-applet-signals.h
@@ -32,7 +32,7 @@ gboolean cd_dbus_applet_emit_on_click_icon (gpointer data, Icon *pClickedIcon, G
 
 gboolean cd_dbus_applet_emit_on_middle_click_icon (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer);
 
-gboolean cd_dbus_applet_emit_on_scroll_icon (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer, int iDirection);
+gboolean cd_dbus_applet_emit_on_scroll_icon (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer, int iDirection, gboolean);
 
 gboolean cd_dbus_applet_emit_on_build_menu (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer, GtkWidget *pAppletMenu);
 


### PR DESCRIPTION
This adds smooth scrolling support for subdocks (slide) and desklets (viewport) + updates signal handler prototypes where necessary