### PR TITLE
clock: improve date format and layout

### DIFF
--- a/clock/src/applet-draw.h
+++ b/clock/src/applet-draw.h
@@ -33,5 +33,9 @@ void cd_clock_draw_analogic (GldiModuleInstance *myApplet, int iWidth, int iHeig
 void cd_clock_render_analogic_to_texture (GldiModuleInstance *myApplet, int iWidth, int iHeight, struct tm *pTime, double fFraction);
 
 
+/** Get a format string that is suitable to pass to strftime() to format
+ * the date to be displayed on the icon or as a label. */
+const char *cd_clock_get_date_format (void);
+
 #endif
 

--- a/clock/src/applet-timer.c
+++ b/clock/src/applet-timer.c
@@ -260,7 +260,7 @@ gboolean cd_clock_update_with_time (GldiModuleInstance *myApplet)
 	gboolean bNewDate = (myData.currentTime.tm_mday != myData.iLastCheckedDay || myData.currentTime.tm_mon != myData.iLastCheckedMonth || myData.currentTime.tm_year != myData.iLastCheckedYear);
 	if (bNewDate)
 	{
-		strftime (s_cDateBuffer, CD_CLOCK_DATE_BUFFER_LENGTH, "%a %d %b", &myData.currentTime);
+		strftime (s_cDateBuffer, CD_CLOCK_DATE_BUFFER_LENGTH, cd_clock_get_date_format (), &myData.currentTime);
 		myData.iLastCheckedDay = myData.currentTime.tm_mday;
 		myData.iLastCheckedMonth = myData.currentTime.tm_mon;
 		myData.iLastCheckedYear = myData.currentTime.tm_year;


### PR DESCRIPTION
Fixes #87 

Also improves the automatic setting of 1/2-line layout on the icon with the "digital" clock version.