### PR TITLE
Fix the use of unnamed function parameters

### DIFF
--- a/Composite-Manager/src/applet-notifications.c
+++ b/Composite-Manager/src/applet-notifications.c
@@ -61,7 +61,7 @@ static void _cd_expose_windows (void)
 	gldi_desktop_present_windows (myDock ? &myDock->container : NULL);
 }
 static unsigned int _expose_windows_timeout = 0;
-static gboolean _cd_expose_windows_idle (gpointer)
+static gboolean _cd_expose_windows_idle (G_GNUC_UNUSED gpointer dummy)
 {
 	_cd_expose_windows ();
 	_expose_windows_timeout = 0;

--- a/Dbus/src/applet-dbus.c
+++ b/Dbus/src/applet-dbus.c
@@ -586,7 +586,7 @@ void cd_dbus_launch_service (void)
 	#endif
 }
 
-static void _child_watch_dummy (GPid pid, gint, gpointer)
+static void _child_watch_dummy (GPid pid, G_GNUC_UNUSED gint status, G_GNUC_UNUSED gpointer dummy)
 {
 	g_spawn_close_pid (pid); // note: this is a no-op
 }

--- a/Dbus/src/interface-applet-methods.c
+++ b/Dbus/src/interface-applet-methods.c
@@ -1001,7 +1001,7 @@ static void _on_map_menuitem (GtkWidget *pMenuItem, gpointer data)
 	if (data) gtk_widget_set_tooltip_text (pMenuItem, (const gchar*)data);
 }
 
-static void _weak_free_helper (gpointer ptr, GObject*)
+static void _weak_free_helper (gpointer ptr, G_GNUC_UNUSED GObject* pObj)
 {
 	g_free (ptr);
 }

--- a/Dbus/src/interface-applet-signals.c
+++ b/Dbus/src/interface-applet-signals.c
@@ -332,7 +332,8 @@ gboolean cd_dbus_applet_emit_on_middle_click_icon (gpointer data, Icon *pClicked
 	return GLDI_NOTIFICATION_INTERCEPT;
 }
 
-gboolean cd_dbus_applet_emit_on_scroll_icon (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer, int iDirection, gboolean)
+gboolean cd_dbus_applet_emit_on_scroll_icon (gpointer data, Icon *pClickedIcon, GldiContainer *pClickedContainer,
+	int iDirection, G_GNUC_UNUSED gboolean bEmulated)
 {
 	if (pClickedIcon == NULL)
 		return GLDI_NOTIFICATION_LET_PASS;

--- a/GMenu/src/applet-apps.c
+++ b/GMenu/src/applet-apps.c
@@ -83,7 +83,7 @@ static void _on_answer_launch_recent (int iClickedButton, GtkWidget *pInteractiv
 }
 
 #ifdef END_INSTALLATION_PID
-static gboolean _show_new_apps_dialog_idle (gpointer)
+static gboolean _show_new_apps_dialog_idle (G_GNUC_UNUSED gpointer dummy)
 {
 	if (s_pNewAppsDialog)
 		gldi_dialog_unhide (s_pNewAppsDialog);

--- a/GMenu/src/applet-entry.c
+++ b/GMenu/src/applet-entry.c
@@ -57,7 +57,7 @@ static void _on_map_entry (GtkWidget *pMenuItem, gpointer data)
 	if (data) gtk_widget_set_tooltip_text (pMenuItem, (const gchar*)data);
 }
 
-static void _weak_free_helper (gpointer ptr, GObject*)
+static void _weak_free_helper (gpointer ptr, G_GNUC_UNUSED GObject *pObj)
 {
 	g_free (ptr);
 }

--- a/GMenu/src/applet-init.c
+++ b/GMenu/src/applet-init.c
@@ -38,7 +38,7 @@ CD_APPLET_DEFINE2_BEGIN ("GMenu",
 	CD_APPLET_REDEFINE_TITLE (N_("Applications Menu"))
 CD_APPLET_DEFINE2_END
 
-static gboolean _menu_request (gpointer, GldiManager*)
+static gboolean _menu_request (G_GNUC_UNUSED gpointer ptr, G_GNUC_UNUSED GldiManager* pManager)
 {
 	gldi_container_present (CAIRO_CONTAINER (myDock)); // currently no-op
 	gldi_wayland_grab_keyboard (CAIRO_CONTAINER (myDock)); // try to grab the keyboard

--- a/GMenu/src/applet-run-dialog.c
+++ b/GMenu/src/applet-run-dialog.c
@@ -337,7 +337,7 @@ static gboolean _entry_event (GtkEditable *entry,
 }
 
 
-static void _cd_menu_on_quick_launch (int iClickedButton, GtkWidget *pInteractiveWidget, gpointer, CairoDialog *pDialog)
+static void _cd_menu_on_quick_launch (int iClickedButton, GtkWidget *pInteractiveWidget, G_GNUC_UNUSED gpointer dummy, CairoDialog *pDialog)
 {
 	if (iClickedButton == 0 || iClickedButton == -1)  // ok ou entree.
 	{

--- a/GMenu/src/applet-tree.c
+++ b/GMenu/src/applet-tree.c
@@ -57,12 +57,12 @@ static void _on_map_entry (GtkWidget *menuitem, gpointer data)
 	if (data) gtk_widget_set_tooltip_text (menuitem, (const gchar*)data);
 }
 
-static void _weak_free_helper (gpointer ptr, GObject*)
+static void _weak_free_helper (gpointer ptr, G_GNUC_UNUSED GObject* pObj)
 {
 	g_free (ptr);
 }
 
-static void _weak_unref_helper (gpointer ptr, GObject*)
+static void _weak_unref_helper (gpointer ptr, G_GNUC_UNUSED GObject* pObj)
 {
 	gmenu_tree_item_unref (ptr);
 }

--- a/Recent-Events/src/applet-notifications.c
+++ b/Recent-Events/src/applet-notifications.c
@@ -55,7 +55,7 @@ struct _OpenFileData
 	GldiAppInfo *app;
 	gchar *cURI;
 };
-static void _menu_item_destroyed (gpointer data, GObject*)
+static void _menu_item_destroyed (gpointer data, G_GNUC_UNUSED GObject *pObj)
 {
 	if (data)
 	{

--- a/Remote-Control/src/applet-init.c
+++ b/Remote-Control/src/applet-init.c
@@ -48,7 +48,7 @@ CD_APPLET_DEFINE2_BEGIN ("Remote-Control",
 	CD_APPLET_REDEFINE_TITLE (N_("Control from keyboard"))
 CD_APPLET_DEFINE2_END
 
-static gboolean _menu_request (gpointer, GldiManager*)
+static gboolean _menu_request (G_GNUC_UNUSED gpointer dummy, G_GNUC_UNUSED GldiManager* pManager)
 {
 	gldi_container_present (CAIRO_CONTAINER (g_pMainDock)); // currently no-op
 	gldi_wayland_grab_keyboard (CAIRO_CONTAINER (g_pMainDock)); // try to grab the keyboard

--- a/gvfs-integration/cairo-dock-gio-vfs.c
+++ b/gvfs-integration/cairo-dock-gio-vfs.c
@@ -760,7 +760,7 @@ struct _AsyncTypeData
 	gchar *cMimeType;
 };
 
-static void _got_default_for_type_async (GObject*, GAsyncResult *pRes, gpointer ptr)
+static void _got_default_for_type_async (G_GNUC_UNUSED GObject* pObj, GAsyncResult *pRes, gpointer ptr)
 {
 	struct _AsyncTypeData *data = (struct _AsyncTypeData*)ptr;
 	GAppInfo *pAppInfo = g_app_info_get_default_for_type_finish (pRes, NULL);
@@ -811,7 +811,7 @@ static void _launch_uri_mime_type (gchar *cURI)
 }
 
 #if GLIB_CHECK_VERSION(2, 74, 0)
-static void _got_default_for_uri_scheme_async (GObject*, GAsyncResult *pRes, gpointer data)
+static void _got_default_for_uri_scheme_async (G_GNUC_UNUSED GObject* pObj, GAsyncResult *pRes, gpointer data)
 {
 	gchar *cURI = (gchar*)data;
 	gboolean bSuccess = FALSE;

--- a/logout/src/applet-logout.c
+++ b/logout/src/applet-logout.c
@@ -673,7 +673,7 @@ static void cd_logout_restart (void)
 	}
 }
 
-static void cd_logout_suspend (GtkMenuItem*, gpointer)
+static void cd_logout_suspend (G_GNUC_UNUSED GtkMenuItem *pMenuItem, G_GNUC_UNUSED gpointer dummy)
 {
 	if (myData.iLoginManager == CD_LOGIND)
 		_logind_action ("Suspend");
@@ -681,7 +681,7 @@ static void cd_logout_suspend (GtkMenuItem*, gpointer)
 		_upower_action (TRUE);
 }
 
-static void cd_logout_hibernate (GtkMenuItem*, gpointer)
+static void cd_logout_hibernate (G_GNUC_UNUSED GtkMenuItem *pMenuItem, G_GNUC_UNUSED gpointer dummy)
 {
 	if (myData.iLoginManager == CD_LOGIND)
 		_logind_action ("Hibernate");
@@ -689,7 +689,7 @@ static void cd_logout_hibernate (GtkMenuItem*, gpointer)
 		_upower_action (FALSE);
 }
 
-static void cd_logout_hybridSleep (GtkMenuItem*, gpointer)
+static void cd_logout_hybridSleep (G_GNUC_UNUSED GtkMenuItem *pMenuItem, G_GNUC_UNUSED gpointer dummy)
 {
 	if (myData.iLoginManager == CD_LOGIND)
 		_logind_action ("HybridSleep");
@@ -706,7 +706,7 @@ static void _logout (void)
 		cairo_dock_launch_command_single (MY_APPLET_SHARE_DATA_DIR"/logout.sh");
 }
 
-static void cd_logout_close_session (GtkMenuItem*, gpointer)  // could use org.gnome.SessionManager.Logout
+static void cd_logout_close_session (G_GNUC_UNUSED GtkMenuItem *pMenuItem, G_GNUC_UNUSED gpointer dummy)  // could use org.gnome.SessionManager.Logout
 {
 	/* Currently, cairo_dock_fm_logout displays to us a window from the DE
 	 * to confirm if we want to close the session or not. So there is a

--- a/switcher/src/applet-notifications.c
+++ b/switcher/src/applet-notifications.c
@@ -41,7 +41,7 @@ static void _cd_expose_desktops (void)
 {
 	gldi_desktop_present_desktops ();
 }
-static gboolean _cd_expose_windows_idle (gpointer)
+static gboolean _cd_expose_windows_idle (G_GNUC_UNUSED gpointer dummy)
 {
 	_cd_expose_windows ();
 	_expose_windows_timeout = 0;


### PR DESCRIPTION
This is a feature only introduced in C23 and is not supported on older compilers. Fixes https://github.com/Cairo-Dock/cairo-dock-core/issues/147