### PR TITLE
build: bump drop-indicator version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,7 +611,7 @@ endif()
 ############# DROP INDICATOR #################
 message (STATUS "> Drop Indicator:")
 set (GETTEXT_DROP_INDICATOR ${GETTEXT_PLUGINS})
-set (VERSION_DROP_INDICATOR "1.1.7")
+set (VERSION_DROP_INDICATOR "1.1.8")
 set (PACKAGE_DROP_INDICATOR "cd-drop_indicator")
 set (drop_indicatordatadir "${pluginsdatadir}/drop-indicator")
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/drop-indicator/data/drop_indicator.conf.in ${CMAKE_CURRENT_BINARY_DIR}/drop-indicator/data/drop_indicator.conf)


### PR DESCRIPTION
This is needed to update config GUI text on existing installations that was fixed recently in e880210