### PR TITLE
powermanager: remove unneeded includes

### DIFF
--- a/powermanager/src/powermanager-proc-acpi.c
+++ b/powermanager/src/powermanager-proc-acpi.c
@@ -20,7 +20,6 @@
 #include <math.h>
 #include <string.h>
 #include <dirent.h>
-#include <dbus/dbus-glib.h>
 
 #include "powermanager-draw.h"
 #include "powermanager-struct.h"

--- a/powermanager/src/powermanager-sys-class.c
+++ b/powermanager/src/powermanager-sys-class.c
@@ -20,7 +20,6 @@
 #include <math.h>
 #include <string.h>
 #include <dirent.h>
-#include <dbus/dbus-glib.h>
 
 #include "powermanager-draw.h"
 #include "powermanager-struct.h"

--- a/powermanager/src/powermanager-upower.c
+++ b/powermanager/src/powermanager-upower.c
@@ -20,7 +20,6 @@
 #include <math.h>
 #include <string.h>
 #include <dirent.h>
-#include <dbus/dbus-glib.h>
 
 #include "powermanager-struct.h"
 #include "powermanager-draw.h"


### PR DESCRIPTION
dbus-glib is not used anymore, the includes are unneccesary