### PR TITLE
small updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,23 +246,14 @@ endif()
 message (STATUS "> UPower:")
 enable_if_not_defined (enable-upower-support)
 if (enable-upower-support)
-	pkg_check_modules (UPOWER upower-glib)  # useful for Powermanager too.
+	pkg_check_modules (UPOWER "upower-glib>=0.99.14") # used by Powermanager
 endif()
 if (UPOWER_FOUND)
 	set (with_upower_support yes)
-	STRING (REGEX REPLACE "\\..*" "" UPOWER_MAJOR "${UPOWER_VERSION}") # 2.28.3 => 2
-	STRING (REGEX REPLACE "[0-9]*\\.([^ ]+)" "\\1" UPOWER_MINOR "${UPOWER_VERSION}")  # 2.28.3 => 2.28
-	STRING (REGEX REPLACE "\\.[0-9]*" "" UPOWER_MINOR "${UPOWER_MINOR}") # 2.28 => 28
-	if (${UPOWER_MAJOR} GREATER 0 OR ${UPOWER_MINOR} GREATER 89)
-		message (STATUS "   Your version of UPower no longer supports suspend/hibernate features")
-		set (with_upower_support "yes (0.99+)")
-	else()
-		set (UPOWER_SUPPORTS_SUSPEND_HIBERNATE 1)
-	endif()
 else()
 	set (with_upower_support no)
-	message (STATUS "Could not find upower-glib; Logout and PowerManager plugin won't be built with UPower support.")
-	message (WARNING "This module is required to compile LogOut and PowerManager applet with UPower support: upower-glib")
+	message (STATUS "Could not find upower-glib>=0.99.14; PowerManager plugin won't be built with UPower support.")
+	message (WARNING "This module is required to compile PowerManager applet with UPower support: upower-glib>=0.99.14")
 	set (MODULES_MISSING "${MODULES_MISSING} upower-glib")
 endif()
 

--- a/GMenu/src/applet-menu.c
+++ b/GMenu/src/applet-menu.c
@@ -72,23 +72,37 @@ static gboolean _make_menu_from_trees (CDSharedMemory *pSharedMemory)
 
 static void _load_trees_async (CDSharedMemory *pSharedMemory)
 {
-	GMenuTree *tree = cd_load_tree_from_file ("applications.menu");
-	if (tree)
-		pSharedMemory->pTrees = g_list_append (pSharedMemory->pTrees, tree);
-
-	if (myConfig.bLoadSettingsMenu)
+	GMenuTree *tree;
+	GList *t;
+	for (t = pSharedMemory->pTrees; t != NULL; t = t->next)
 	{
-		tree = cd_load_tree_from_file ("settings.menu");
-		if (tree)
-			pSharedMemory->pTrees = g_list_append (pSharedMemory->pTrees, tree);
+		tree = t->data;
+		// this does all the heavy work of parsing the .menu and each desktop files:
+		if (! gmenu_tree_load_sync (tree, NULL))
+		{
+			// free this tree if it failed to load (will be removed later)
+			g_object_unref (tree);
+			t->data = NULL;
+		}
 	}
+	// remove all menu trees that failed to load
+	pSharedMemory->pTrees = g_list_remove_all (pSharedMemory->pTrees, NULL);
 }
 
 static void _free_shared_memory (CDSharedMemory *pSharedMemory)
 {
-	g_list_foreach (pSharedMemory->pTrees, (GFunc)g_object_unref, NULL);
-	g_list_free (pSharedMemory->pTrees);
+	g_list_free_full (pSharedMemory->pTrees, g_object_unref);
 	g_free (pSharedMemory);
+}
+
+static GMenuTree *_create_tree (const char *cMenuFile)
+{
+	gchar *cMenuFileName = cd_find_menu_file (cMenuFile);
+	GMenuTree *tree = cMenuFileName ? gmenu_tree_new (cMenuFileName,
+		GMENU_TREE_FLAGS_INCLUDE_NODISPLAY| GMENU_TREE_FLAGS_INCLUDE_EXCLUDED)
+		: NULL;
+	g_free (cMenuFileName);
+	return tree;
 }
 
 void cd_menu_start (void)
@@ -103,6 +117,22 @@ void cd_menu_start (void)
 		(GFreeFunc) _free_shared_memory,
 		pSharedMemory);
 	
+	/** Note: we create the GMenuTree objects here to ensure the
+	 * corresponding GObject is registered. This is to avoid a bug
+	 * in GLib where registering types from multiple threads can
+	 * lead to a deadlock, see:
+	 * https://github.com/Cairo-Dock/cairo-dock-core/issues/247
+	 * https://gitlab.gnome.org/GNOME/glib/-/issues/541
+	 */
+	GMenuTree *tree = _create_tree ("applications.menu");
+	if (tree) pSharedMemory->pTrees = g_list_append (pSharedMemory->pTrees, tree);
+	if (myConfig.bLoadSettingsMenu)
+	{
+		tree = _create_tree ("settings.menu");
+		if (tree) pSharedMemory->pTrees = g_list_append (pSharedMemory->pTrees, tree);
+	}
+	
+	// loading trees is then done in a worker thread
 	if (cairo_dock_is_loading ())
 		gldi_task_launch_delayed (myData.pTask, 0);  // 0 <=> g_idle
 	else

--- a/GMenu/src/applet-tree.c
+++ b/GMenu/src/applet-tree.c
@@ -381,7 +381,7 @@ static gchar * _check_file_exists (const gchar *cDir, const gchar *cPrefix, cons
 
 static const gchar *cPrefixNames[] = {"", "gnome-", "kde-", "kde4-", "xfce-", "lxde-", NULL};
 
-static gchar * cd_find_menu_file (const gchar *cMenuFile)
+gchar * cd_find_menu_file (const gchar *cMenuFile)
 {
 	gchar *cMenuFileName = NULL, *cXdgMenuPath = NULL;
 	const gchar *cMenuPrefix = g_getenv ("XDG_MENU_PREFIX"); // e.g. on xfce, it contains "xfce-", nothing on gnome
@@ -437,17 +437,3 @@ static gchar * cd_find_menu_file (const gchar *cMenuFile)
 	return cMenuFileName;
 }
 
-GMenuTree *cd_load_tree_from_file (const gchar *cMenuFile)
-{
-	gchar *cMenuFileName = cd_find_menu_file (cMenuFile);
-	GMenuTree *tree = gmenu_tree_new (cMenuFileName,
-		GMENU_TREE_FLAGS_INCLUDE_NODISPLAY| GMENU_TREE_FLAGS_INCLUDE_EXCLUDED);
-	// this does all the heavy work of parsing the .menu and each desktop files:
-	if (! gmenu_tree_load_sync (tree, NULL))
-	{
-		g_object_unref (tree);
-		tree = NULL;
-	}
-	g_free (cMenuFileName);
-	return tree;
-}

--- a/GMenu/src/applet-tree.h
+++ b/GMenu/src/applet-tree.h
@@ -24,14 +24,11 @@
 #define GMENU_I_KNOW_THIS_IS_UNSTABLE
 #include <gmenu-tree.h>
 
-
 void reload_image_menu_items (void);
-
-
-GMenuTree *cd_load_tree_from_file (const gchar *cMenuFile);
-
 
 void cd_append_tree_in_menu (GMenuTree *tree, GtkWidget *pMenu);
 
+gchar *cd_find_menu_file (const gchar *cMenuFile);
 
 #endif
+

--- a/powermanager/src/CMakeLists.txt
+++ b/powermanager/src/CMakeLists.txt
@@ -26,9 +26,6 @@ add_definitions (-DMY_APPLET_DOCK_VERSION="${dock_version}")
 add_definitions (-DMY_APPLET_ICON_FILE="icon.png")
 if (${UPOWER_FOUND})
 	add_definitions (-DCD_UPOWER_AVAILABLE=1)
-	if (NOT UPOWER_SUPPORTS_SUSPEND_HIBERNATE)
-		add_definitions (-DCD_UPOWER_0_99=1)
-	endif()
 endif()
 
 include_directories (

--- a/powermanager/src/powermanager-init.c
+++ b/powermanager/src/powermanager-init.c
@@ -66,6 +66,11 @@ CD_APPLET_STOP_BEGIN
 	{
 		g_source_remove (myData.checkLoop);
 	}
+	
+	if (myData.pPowerPrefApp)
+		g_object_unref (myData.pPowerPrefApp);
+	if (myData.pPowerStatsApp)
+		gldi_object_unref (GLDI_OBJECT (myData.pPowerStatsApp));
 CD_APPLET_STOP_END
 
 

--- a/powermanager/src/powermanager-init.c
+++ b/powermanager/src/powermanager-init.c
@@ -58,8 +58,6 @@ CD_APPLET_STOP_BEGIN
 	CD_APPLET_UNREGISTER_FOR_CLICK_EVENT;
 	CD_APPLET_UNREGISTER_FOR_BUILD_MENU_EVENT;
 	
-	gldi_task_discard (myData.pTask);
-	
 	// stop UPower monitoring
 	cd_upower_stop ();
 	

--- a/powermanager/src/powermanager-menu-functions.c
+++ b/powermanager/src/powermanager-menu-functions.c
@@ -31,60 +31,66 @@ CD_APPLET_ON_CLICK_BEGIN
 	cd_powermanager_bubble ();
 CD_APPLET_ON_CLICK_END
 
-static void power_launch_cmd (GtkMenuItem *menu_item, const gchar *cCommand)
+static void _power_launch_settings (G_GNUC_UNUSED GtkMenuItem *menu_item, G_GNUC_UNUSED gpointer data)
 {
-	GError *erreur = NULL;
-	g_spawn_command_line_async (cCommand, &erreur);
-
-	if (erreur != NULL)
+	CD_APPLET_ENTER;
+	
+	if (myData.cPowerPrefCmd)
 	{
-		cd_warning ("PM : %s", erreur->message);
-		g_error_free (erreur);
+		
+		cairo_dock_launch_command_argv_full2 (myData.cPowerPrefCmd, NULL,
+			GLDI_LAUNCH_GUI | GLDI_LAUNCH_SLICE, myData.pPowerPrefApp);
 	}
+	
+	CD_APPLET_LEAVE ();
 }
+
+static void _power_launch_stats (G_GNUC_UNUSED GtkMenuItem *menu_item, G_GNUC_UNUSED gpointer data)
+{
+	CD_APPLET_ENTER;
+	
+	if (myData.pPowerStatsApp)
+		gldi_app_info_launch (myData.pPowerStatsApp, NULL);
+	
+	CD_APPLET_LEAVE ();
+}
+
+static const char * const s_gnome_power_settings[] = {"gnome-control-center", "power", NULL};
 
 CD_APPLET_ON_BUILD_MENU_BEGIN
 	gboolean bAddSeparator = FALSE;
 	// Power preferences
-	static gboolean bPowerPrefChecked = FALSE;
-	static const gchar *cPowerPrefCmd = NULL;
-	if (!bPowerPrefChecked)
+	if (!myData.bPowerMenuChecked)
 	{
-		bPowerPrefChecked = TRUE;
+		myData.bPowerMenuChecked = TRUE;
+		
+		// preferences
 		gchar *cResult = cairo_dock_launch_command_sync ("which gnome-control-center");  // Gnome3
 		if (cResult != NULL && *cResult == '/')
 		{
-			cPowerPrefCmd = "gnome-control-center power";
-		}
-		else
-		{
-			g_free (cResult);
-			cResult = cairo_dock_launch_command_sync ("which gnome-power-preferences");  // Gnome2
-			if (cResult != NULL && *cResult == '/')
-				cPowerPrefCmd = "gnome-power-preferences";
-		}  /// TODO: handle other DE ...
+			myData.cPowerPrefCmd = s_gnome_power_settings;
+			GDesktopAppInfo *tmp = g_desktop_app_info_new ("org.gnome.Settings.desktop");
+			myData.pPowerPrefApp = tmp ? G_APP_INFO (tmp) : NULL;
+		}  /// TODO: handle other DE ... (should be moved to *-integration?)
 		g_free (cResult);
+		
+		// stats
+		cResult = cairo_dock_register_class ("org.gnome.powerstats");
+		if (cResult)
+		{
+			myData.pPowerStatsApp = cairo_dock_get_class_app_info (cResult);
+			if (myData.pPowerStatsApp) gldi_object_ref (GLDI_OBJECT (myData.pPowerStatsApp));
+			g_free (cResult);
+		}
 	}
-	if (cPowerPrefCmd)
+	if (myData.cPowerPrefCmd)
 	{
-		CD_APPLET_ADD_IN_MENU_WITH_STOCK_AND_DATA (D_("Set up power management"), MY_APPLET_SHARE_DATA_DIR"/default-charge.svg", power_launch_cmd, CD_APPLET_MY_MENU, (gpointer)cPowerPrefCmd);
+		CD_APPLET_ADD_IN_MENU_WITH_STOCK_AND_DATA (D_("Set up power management"), MY_APPLET_SHARE_DATA_DIR"/default-charge.svg", _power_launch_settings, CD_APPLET_MY_MENU, NULL);
 		bAddSeparator = TRUE;
 	}
-	
-	// Power statistics
-	static gboolean bPowerStatsChecked = FALSE;
-	static const gchar *cPowerStatsCmd = NULL;
-	if (!bPowerStatsChecked)
+	if (myData.pPowerStatsApp)
 	{
-		bPowerStatsChecked = TRUE;
-		gchar *cResult = cairo_dock_launch_command_sync ("which gnome-power-statistics");
-		if (cResult != NULL && *cResult == '/')  /// TODO: other DE...
-			cPowerStatsCmd = "gnome-power-statistics";
-		g_free (cResult);
-	}
-	if (cPowerStatsCmd)
-	{
-		CD_APPLET_ADD_IN_MENU_WITH_STOCK_AND_DATA (D_("Power statistics"), MY_APPLET_SHARE_DATA_DIR"/default-charge.svg", power_launch_cmd, CD_APPLET_MY_MENU, (gpointer)cPowerStatsCmd);
+		CD_APPLET_ADD_IN_MENU_WITH_STOCK_AND_DATA (D_("Power statistics"), MY_APPLET_SHARE_DATA_DIR"/default-charge.svg", _power_launch_stats, CD_APPLET_MY_MENU, NULL);
 		bAddSeparator = TRUE;
 	}
 	

--- a/powermanager/src/powermanager-struct.h
+++ b/powermanager/src/powermanager-struct.h
@@ -131,6 +131,12 @@ struct _AppletData {
 	gint iStatTimeCount;
 	
 	gint iOnBatteryImage;  // -1 = no image yet, 0 = charging, 1 = on battery
+	
+	// menu commands
+	gboolean bPowerMenuChecked;
+	const gchar * const * cPowerPrefCmd; // set to a static string, do not free
+	GAppInfo *pPowerPrefApp; // helper for launching the above (can be NULL)
+	GldiAppInfo *pPowerStatsApp; // our own app info for the preferences app (since no custom command is required)
 	} ;
 
 

--- a/powermanager/src/powermanager-struct.h
+++ b/powermanager/src/powermanager-struct.h
@@ -79,14 +79,6 @@ struct _AppletConfig {
 } ;
 
 
-#ifdef CD_UPOWER_AVAILABLE
-typedef struct {
-	UpClient *pUPowerClient;
-	GList *pBatteryDeviceList;
-	gboolean bFirstUpdate;
-	} CDSharedMemory;
-#endif
-
 struct _AppletData {
 	// UPower
 	#ifdef CD_UPOWER_AVAILABLE

--- a/powermanager/src/powermanager-struct.h
+++ b/powermanager/src/powermanager-struct.h
@@ -83,17 +83,17 @@ struct _AppletConfig {
 typedef struct {
 	UpClient *pUPowerClient;
 	GList *pBatteryDeviceList;
+	gboolean bFirstUpdate;
 	} CDSharedMemory;
 #endif
 
 struct _AppletData {
-	GldiTask *pTask;  // async task to find the available backend (launched on startup)
-	
 	// UPower
 	#ifdef CD_UPOWER_AVAILABLE
 	UpClient *pUPowerClient;
 	gint iSignalIDAdded;
 	gint iSignalIDRemoved;
+	GCancellable *pCancel;
 	#endif
 	GList *pBatteryDeviceList;
 	

--- a/powermanager/src/powermanager-upower.c
+++ b/powermanager/src/powermanager-upower.c
@@ -29,28 +29,31 @@
 
 #ifdef CD_UPOWER_AVAILABLE  // code with libupower
 
-static GList * _cd_upower_add_and_ref_device_if_battery (UpDevice *pDevice, GList *pBatteryDeviceList)
+static void _cd_upower_update_state (gboolean bFirstUpdate);
+static void _on_device_changed (G_GNUC_UNUSED UpDevice *pDevice, G_GNUC_UNUSED GParamSpec *pSpec, G_GNUC_UNUSED gpointer data);
+static void _free_battery_dev (gpointer ptr);
+
+static gboolean _cd_upower_add_and_ref_device_if_battery (UpDevice *pDevice, GList **pBatteryDeviceList)
 {
 	UpDeviceKind kind;
 	g_object_get (G_OBJECT (pDevice), "kind", &kind, NULL);
 	if (kind == UP_DEVICE_KIND_BATTERY)
 	{
-		pBatteryDeviceList = g_list_append (pBatteryDeviceList, pDevice);
+		*pBatteryDeviceList = g_list_prepend (*pBatteryDeviceList, pDevice);
 		g_object_ref (pDevice);  // since the object does not belong to us, we ref it here, and we'll keep our ref until the end of the applet.
+		return TRUE;
 	}
-	return pBatteryDeviceList;
+	return FALSE;
 }
 
-static void _cd_upower_update_state (CDSharedMemory *pSharedMemory);
-
-static void _on_got_devices (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, gpointer data)
+static void _on_got_devices (GObject *pObj, GAsyncResult *pRes, G_GNUC_UNUSED gpointer data)
 {
 	CD_APPLET_ENTER;
-	CDSharedMemory *pSharedMemory = (CDSharedMemory*)data;
 	
 	// find the battery devices.
+	UpClient *pUPowerClient = UP_CLIENT (pObj);
 	GError *err = NULL;
-	GPtrArray *pDevices = up_client_get_devices_finish (pSharedMemory->pUPowerClient, pRes, &err);
+	GPtrArray *pDevices = up_client_get_devices_finish (pUPowerClient, pRes, &err);
 	if (!pDevices)
 	{
 		if (! g_error_matches (err, G_IO_ERROR, G_IO_ERROR_CANCELLED))
@@ -59,7 +62,7 @@ static void _on_got_devices (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, gp
 			_cd_upower_update_state (TRUE); // try fallback in this case (note: if cancelled, we should not call this function)
 		}
 		g_error_free (err);
-		g_object_unref (pSharedMemory->pUPowerClient);
+		g_object_unref (pUPowerClient);
 	}
 	else
 	{
@@ -69,25 +72,24 @@ static void _on_got_devices (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, gp
 		for (i = 0; i < pDevices->len; i ++)
 		{
 			pDevice = g_ptr_array_index (pDevices, i);
-			pBatteryDeviceList = _cd_upower_add_and_ref_device_if_battery (pDevice, pBatteryDeviceList);
+			_cd_upower_add_and_ref_device_if_battery (pDevice, &pBatteryDeviceList);
 		}
 		if (pBatteryDeviceList == NULL)
 			cd_debug ("no battery found amongst %d devices", pDevices->len);
 			// we keep pUPowerClient since a battery might be added later
 		g_ptr_array_unref (pDevices);
 		
-		pSharedMemory->pBatteryDeviceList = pBatteryDeviceList;
-		_cd_upower_update_state (pSharedMemory);
+		myData.pUPowerClient = pUPowerClient;
+		myData.pBatteryDeviceList = pBatteryDeviceList;
+		_cd_upower_update_state (TRUE);
 	}
 	
-	g_free (pSharedMemory); // not needed anymore
 	CD_APPLET_LEAVE ();
 }
 
-static void _on_got_upower (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, gpointer data)
+static void _on_got_upower (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, G_GNUC_UNUSED gpointer data)
 {
 	CD_APPLET_ENTER;
-	CDSharedMemory *pSharedMemory = (CDSharedMemory*)data;
 	
 	GError *err = NULL;
 	UpClient *pUPowerClient = up_client_new_finish (pRes, &err);
@@ -99,13 +101,8 @@ static void _on_got_upower (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, gpo
 			_cd_upower_update_state (TRUE); // try fallback in this case (note: if cancelled, we should not call this function)
 		}
 		g_error_free (err);
-		g_free (pSharedMemory);
 	}
-	else
-	{
-		pSharedMemory->pUPowerClient = pUPowerClient;
-		up_client_get_devices_async (pUPowerClient, myData.pCancel, _on_got_devices, pSharedMemory);
-	}
+	else up_client_get_devices_async (pUPowerClient, myData.pCancel, _on_got_devices, NULL);
 	
 	CD_APPLET_LEAVE ();
 }
@@ -154,37 +151,23 @@ static void _fetch_current_values (GList *pBatteryDeviceList)
 		myData.iTime = cd_estimate_time ();
 }
 
-static void _on_device_list_changed_free_data (void)
-{
-	cd_debug ("Device list changed");
-	g_free (myData.cTechnology);
-	myData.cTechnology = NULL;
-	g_free (myData.cVendor);
-	myData.cVendor = NULL;
-	g_free (myData.cModel);
-	myData.cModel = NULL;
-}
-
 static void _on_device_added (UpClient *pClient, UpDevice *pDevice, gpointer data)
 {
 	CD_APPLET_ENTER;
-	if (pClient != myData.pUPowerClient) // should not happen...
+	if (pClient != myData.pUPowerClient) // should not happen, not sure what to do
 	{
 		g_object_unref (myData.pUPowerClient);
 		myData.pUPowerClient = NULL;
 	}
 
-	// if it's really a new device (yes, be secured...)
-	if (g_list_find (myData.pBatteryDeviceList, pDevice) == NULL)
+	// if it's really a new device (yes, be secured...) and it's a battery
+	if (g_list_find (myData.pBatteryDeviceList, pDevice) == NULL &&
+		_cd_upower_add_and_ref_device_if_battery (pDevice, &myData.pBatteryDeviceList))
 	{
-		_on_device_list_changed_free_data (); // free data
-
 		// update state: get all devices and all info
-		CDSharedMemory SharedMemory;
-		SharedMemory.pBatteryDeviceList = _cd_upower_add_and_ref_device_if_battery (pDevice, myData.pBatteryDeviceList);
-		SharedMemory.pUPowerClient = pClient;
-		SharedMemory.bFirstUpdate = FALSE;
-		_cd_upower_update_state (&SharedMemory);
+		_cd_upower_update_state (FALSE);
+		// connect to be notified for changes
+		g_signal_connect (pDevice, "notify", G_CALLBACK (_on_device_changed), NULL);
 	}
 	CD_APPLET_LEAVE ();
 }
@@ -201,15 +184,11 @@ static void _on_device_removed (UpClient *pClient, UpDevice *pDevice, gpointer d
 	GList *pOldDevice = g_list_find (myData.pBatteryDeviceList, pDevice);
 	if (pOldDevice != NULL) // if we've already added this device (yes, be secured)
 	{
-		_on_device_list_changed_free_data (); // free data
-		g_object_unref (pDevice); // unref, we no longer need it...
+		_free_battery_dev (pDevice); // unref and disconnect signal
 
 		// update state: get all devices and all info
-		CDSharedMemory SharedMemory;
-		SharedMemory.pBatteryDeviceList = g_list_delete_link (myData.pBatteryDeviceList, pOldDevice);
-		SharedMemory.pUPowerClient = pClient;
-		SharedMemory.bFirstUpdate = FALSE;
-		_cd_upower_update_state (&SharedMemory);
+		myData.pBatteryDeviceList = g_list_delete_link (myData.pBatteryDeviceList, pOldDevice);
+		_cd_upower_update_state (FALSE);
 	}
 	CD_APPLET_LEAVE ();
 }
@@ -231,18 +210,26 @@ static void _on_device_changed (G_GNUC_UNUSED UpDevice *pDevice, G_GNUC_UNUSED G
 	CD_APPLET_LEAVE ();
 }
 
-// Can be launched the first time (with the Task) or when a device is added/removed after.
-static void _cd_upower_update_state (CDSharedMemory *pSharedMemory)
+// Can be called the first time (when getting the list of devices) or when a device is added/removed after.
+static void _cd_upower_update_state (gboolean bFirstUpdate)
 {
-	if (pSharedMemory->pUPowerClient == NULL)  // no UPower available, try to find the battery by ourselves.
+	if (myData.pUPowerClient == NULL)  // no UPower available, try to find the battery by ourselves.
 	{
 		cd_debug ("no UPower available");
 		cd_check_power_files ();
 	}
 	else  // UPower is available, fetch the values we got from it.
 	{
+		// clear previous values
+		g_free (myData.cTechnology);
+		myData.cTechnology = NULL;
+		g_free (myData.cVendor);
+		myData.cVendor = NULL;
+		g_free (myData.cModel);
+		myData.cModel = NULL;
+		
 		// fetch the current values we got on the devices
-		_fetch_current_values (pSharedMemory->pBatteryDeviceList);
+		_fetch_current_values (myData.pBatteryDeviceList);
 		
 		// fetch static values of the devices, and watch for any change
 		UpDevice *pDevice;
@@ -253,7 +240,7 @@ static void _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 		gdouble fMaxAvailableCapacity = 0., fTmp;
 		UpDeviceTechnology iTechnology;
 		gboolean bFirst = TRUE;
-		for (pItem = pSharedMemory->pBatteryDeviceList ; pItem != NULL ; pItem = g_list_next (pItem))
+		for (pItem = myData.pBatteryDeviceList ; pItem != NULL ; pItem = g_list_next (pItem))
 		{
 			pDevice = pItem->data;
 			
@@ -282,10 +269,7 @@ static void _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 			g_free (cVendor);
 			g_free (cModel);
 
-			if (pSharedMemory->bFirstUpdate // only the first time
-				|| myData.pBatteryDeviceList == NULL // or if it's a new device
-				|| g_list_find (myData.pBatteryDeviceList, pDevice) == NULL)
-				// or compare the up_device_get_object_path (pDevice) ?
+			if (bFirstUpdate)
 			{
 				/* watch for any change. A priori, no need to watch the
 				 * "onBattery" signal on the client, since we can deduce this
@@ -309,21 +293,14 @@ static void _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 			myData.cModel = g_string_free (sModel, FALSE);
 		}
 
-		if (pSharedMemory->bFirstUpdate // only the first time
-			|| pSharedMemory->pUPowerClient != myData.pUPowerClient) // or a new client (should not happen...)
+		if (bFirstUpdate)
 		{
-			myData.iSignalIDAdded = g_signal_connect (pSharedMemory->pUPowerClient,
+			myData.iSignalIDAdded = g_signal_connect (myData.pUPowerClient,
 				"device-added", G_CALLBACK (_on_device_added), NULL);
-			myData.iSignalIDRemoved = g_signal_connect (pSharedMemory->pUPowerClient,
+			myData.iSignalIDRemoved = g_signal_connect (myData.pUPowerClient,
 				"device-removed", G_CALLBACK (_on_device_removed), NULL);
 			// Note: these signals (removed and added) are also send when resuming from suspend...
 		}
-		
-		// keep our client and devices.
-		myData.pUPowerClient = pSharedMemory->pUPowerClient;
-		pSharedMemory->pUPowerClient = NULL;
-		myData.pBatteryDeviceList = pSharedMemory->pBatteryDeviceList;
-		pSharedMemory->pBatteryDeviceList = NULL;  // so we won't unref it in the destroy callback of the task.
 	}
 	
 	// in any case, update the icon to show the current state we are in.
@@ -333,9 +310,7 @@ static void _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 void cd_powermanager_start (void)
 {
 	myData.pCancel = g_cancellable_new ();
-	CDSharedMemory *pSharedMemory = g_new0 (CDSharedMemory, 1);
-	pSharedMemory->bFirstUpdate = TRUE;
-	up_client_new_async (myData.pCancel, _on_got_upower, pSharedMemory);
+	up_client_new_async (myData.pCancel, _on_got_upower, NULL);
 }
 
 static void _free_battery_dev (gpointer ptr)

--- a/powermanager/src/powermanager-upower.c
+++ b/powermanager/src/powermanager-upower.c
@@ -41,44 +41,73 @@ static GList * _cd_upower_add_and_ref_device_if_battery (UpDevice *pDevice, GLis
 	return pBatteryDeviceList;
 }
 
-static void _cd_upower_connect_async (CDSharedMemory *pSharedMemory)
+static void _cd_upower_update_state (CDSharedMemory *pSharedMemory);
+
+static void _on_got_devices (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, gpointer data)
 {
-	// connect to UPower on Dbus.
-	UpClient *pUPowerClient = up_client_new ();
+	CD_APPLET_ENTER;
+	CDSharedMemory *pSharedMemory = (CDSharedMemory*)data;
 	
-	// get the list of devices.
-	if (pUPowerClient == NULL
-	#ifndef CD_UPOWER_0_99 // no longer available with UPower 0.99+
-		|| ! up_client_enumerate_devices_sync (pUPowerClient, NULL, NULL)
-	#endif
-		)
-	{	
-		cd_warning ("couldn't get devices from UPower daemon");
-		if (pUPowerClient)
-			g_object_unref (pUPowerClient);
-		return;
-	}
-	
-	// find the battery device.
-	GPtrArray *pDevices = up_client_get_devices (pUPowerClient);
-	g_return_if_fail (pDevices != NULL);  // just to be sure.
-	UpDevice *pDevice;
-	GList *pBatteryDeviceList = NULL;
-	guint i;
-	for (i = 0; i < pDevices->len; i ++)
+	// find the battery devices.
+	GError *err = NULL;
+	GPtrArray *pDevices = up_client_get_devices_finish (pSharedMemory->pUPowerClient, pRes, &err);
+	if (!pDevices)
 	{
-		pDevice = g_ptr_array_index (pDevices, i);
-		pBatteryDeviceList = _cd_upower_add_and_ref_device_if_battery (pDevice, pBatteryDeviceList);
+		if (! g_error_matches (err, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+		{
+			cd_warning ("Error getting devices from UPower daemon: %s", err->message);
+			_cd_upower_update_state (TRUE); // try fallback in this case (note: if cancelled, we should not call this function)
+		}
+		g_error_free (err);
+		g_object_unref (pSharedMemory->pUPowerClient);
 	}
-	if (pBatteryDeviceList == NULL)
+	else
 	{
-		cd_debug ("no battery found amongst %d devices", pDevices->len);
-		/* g_object_unref (pUPowerClient); // => if we launch the dock without any battery and then connect the battery, we need to be notified
-		return;*/ 
+		UpDevice *pDevice;
+		GList *pBatteryDeviceList = NULL;
+		guint i;
+		for (i = 0; i < pDevices->len; i ++)
+		{
+			pDevice = g_ptr_array_index (pDevices, i);
+			pBatteryDeviceList = _cd_upower_add_and_ref_device_if_battery (pDevice, pBatteryDeviceList);
+		}
+		if (pBatteryDeviceList == NULL)
+			cd_debug ("no battery found amongst %d devices", pDevices->len);
+			// we keep pUPowerClient since a battery might be added later
+		g_ptr_array_unref (pDevices);
+		
+		pSharedMemory->pBatteryDeviceList = pBatteryDeviceList;
+		_cd_upower_update_state (pSharedMemory);
 	}
 	
-	pSharedMemory->pUPowerClient = pUPowerClient;
-	pSharedMemory->pBatteryDeviceList = pBatteryDeviceList;
+	g_free (pSharedMemory); // not needed anymore
+	CD_APPLET_LEAVE ();
+}
+
+static void _on_got_upower (G_GNUC_UNUSED GObject *pObj, GAsyncResult *pRes, gpointer data)
+{
+	CD_APPLET_ENTER;
+	CDSharedMemory *pSharedMemory = (CDSharedMemory*)data;
+	
+	GError *err = NULL;
+	UpClient *pUPowerClient = up_client_new_finish (pRes, &err);
+	if (!pUPowerClient)
+	{
+		if (! g_error_matches (err, G_IO_ERROR, G_IO_ERROR_CANCELLED))
+		{
+			cd_warning ("Error connecting to UPower daemon: %s", err->message);
+			_cd_upower_update_state (TRUE); // try fallback in this case (note: if cancelled, we should not call this function)
+		}
+		g_error_free (err);
+		g_free (pSharedMemory);
+	}
+	else
+	{
+		pSharedMemory->pUPowerClient = pUPowerClient;
+		up_client_get_devices_async (pUPowerClient, myData.pCancel, _on_got_devices, pSharedMemory);
+	}
+	
+	CD_APPLET_LEAVE ();
 }
 
 static void _fetch_current_values (GList *pBatteryDeviceList)
@@ -136,8 +165,6 @@ static void _on_device_list_changed_free_data (void)
 	myData.cModel = NULL;
 }
 
-static gboolean _cd_upower_update_state (CDSharedMemory *pSharedMemory);
-
 static void _on_device_added (UpClient *pClient, UpDevice *pDevice, gpointer data)
 {
 	CD_APPLET_ENTER;
@@ -156,6 +183,7 @@ static void _on_device_added (UpClient *pClient, UpDevice *pDevice, gpointer dat
 		CDSharedMemory SharedMemory;
 		SharedMemory.pBatteryDeviceList = _cd_upower_add_and_ref_device_if_battery (pDevice, myData.pBatteryDeviceList);
 		SharedMemory.pUPowerClient = pClient;
+		SharedMemory.bFirstUpdate = FALSE;
 		_cd_upower_update_state (&SharedMemory);
 	}
 	CD_APPLET_LEAVE ();
@@ -180,16 +208,13 @@ static void _on_device_removed (UpClient *pClient, UpDevice *pDevice, gpointer d
 		CDSharedMemory SharedMemory;
 		SharedMemory.pBatteryDeviceList = g_list_delete_link (myData.pBatteryDeviceList, pOldDevice);
 		SharedMemory.pUPowerClient = pClient;
+		SharedMemory.bFirstUpdate = FALSE;
 		_cd_upower_update_state (&SharedMemory);
 	}
 	CD_APPLET_LEAVE ();
 }
 
-#ifdef CD_UPOWER_0_99 // one more param
 static void _on_device_changed (G_GNUC_UNUSED UpDevice *pDevice, G_GNUC_UNUSED GParamSpec *pSpec, G_GNUC_UNUSED gpointer data)
-#else
-static void _on_device_changed (G_GNUC_UNUSED UpDevice *pDevice, G_GNUC_UNUSED gpointer data)
-#endif
 {
 	// The applet is removed just before an update...
 	if (myApplet == NULL)
@@ -207,9 +232,8 @@ static void _on_device_changed (G_GNUC_UNUSED UpDevice *pDevice, G_GNUC_UNUSED g
 }
 
 // Can be launched the first time (with the Task) or when a device is added/removed after.
-static gboolean _cd_upower_update_state (CDSharedMemory *pSharedMemory)
+static void _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 {
-	CD_APPLET_ENTER;
 	if (pSharedMemory->pUPowerClient == NULL)  // no UPower available, try to find the battery by ourselves.
 	{
 		cd_debug ("no UPower available");
@@ -258,7 +282,7 @@ static gboolean _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 			g_free (cVendor);
 			g_free (cModel);
 
-			if (myData.pTask != NULL // only the first time
+			if (pSharedMemory->bFirstUpdate // only the first time
 				|| myData.pBatteryDeviceList == NULL // or if it's a new device
 				|| g_list_find (myData.pBatteryDeviceList, pDevice) == NULL)
 				// or compare the up_device_get_object_path (pDevice) ?
@@ -270,11 +294,7 @@ static gboolean _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 				 * find a battery device, it will stay here forever, so we don't
 				 * need to watch for the destruction/creation of a battery device.
 				 */
-				#ifdef CD_UPOWER_0_99 // Now called notify
 				g_signal_connect (pDevice, "notify", G_CALLBACK (_on_device_changed), NULL);
-				#else
-				g_signal_connect (pDevice, "changed", G_CALLBACK (_on_device_changed), NULL);
-				#endif
 			}
 
 			bFirst = FALSE;
@@ -289,7 +309,7 @@ static gboolean _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 			myData.cModel = g_string_free (sModel, FALSE);
 		}
 
-		if (myData.pTask != NULL // only the first time
+		if (pSharedMemory->bFirstUpdate // only the first time
 			|| pSharedMemory->pUPowerClient != myData.pUPowerClient) // or a new client (should not happen...)
 		{
 			myData.iSignalIDAdded = g_signal_connect (pSharedMemory->pUPowerClient,
@@ -308,40 +328,14 @@ static gboolean _cd_upower_update_state (CDSharedMemory *pSharedMemory)
 	
 	// in any case, update the icon to show the current state we are in.
 	update_icon ();
-
-	if (myData.pTask != NULL)
-	{
-		gldi_task_discard (myData.pTask);
-		myData.pTask = NULL;
-	}
-	
-	CD_APPLET_LEAVE (FALSE);
-}
-
-static void _free_shared_memory (CDSharedMemory *pSharedMemory)
-{
-	if (pSharedMemory->pUPowerClient)
-		g_object_unref (pSharedMemory->pUPowerClient);
-	if (pSharedMemory->pBatteryDeviceList)
-		g_list_foreach (pSharedMemory->pBatteryDeviceList, (GFunc) g_object_unref, NULL);  // remove the ref we took on it.
-	g_free (pSharedMemory);
 }
 
 void cd_powermanager_start (void)
 {
-	if (myData.pTask != NULL)
-	{
-		gldi_task_discard (myData.pTask);
-		myData.pTask = NULL;
-	}
-	
+	myData.pCancel = g_cancellable_new ();
 	CDSharedMemory *pSharedMemory = g_new0 (CDSharedMemory, 1);
-	myData.pTask = gldi_task_new_full (0,
-		(GldiGetDataAsyncFunc) _cd_upower_connect_async,
-		(GldiUpdateSyncFunc) _cd_upower_update_state,
-		(GFreeFunc) _free_shared_memory,
-		pSharedMemory);
-	gldi_task_launch (myData.pTask);
+	pSharedMemory->bFirstUpdate = TRUE;
+	up_client_new_async (myData.pCancel, _on_got_upower, pSharedMemory);
 }
 
 static void _free_battery_dev (gpointer ptr)
@@ -353,6 +347,13 @@ static void _free_battery_dev (gpointer ptr)
 
 void cd_upower_stop (void)
 {
+	if (myData.pCancel != NULL)
+	{
+		g_cancellable_cancel (myData.pCancel);
+		g_object_unref (myData.pCancel);
+		myData.pCancel = NULL;
+	}
+	
 	if (myData.pUPowerClient != NULL)
 	{
 		if (myData.iSignalIDAdded != 0)


### PR DESCRIPTION
GMenu: try to ensure that we init the GObject types used in the main thread as a workaround for https://github.com/Cairo-Dock/cairo-dock-core/issues/247

powermanager: update to using the async UPower interface (available since 0.99.14) and to the new API when launching commands from the menu