### PR TITLE
Xgamma: Wayland support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ include (GNUInstallDirs)
 
 ########### project ###############
 
-set (VERSION "3.6.100")
+set (VERSION "3.6.101")
 # can be different from VERSION, e.g. if a new version of plugins does not depend on things added to core
-set (CORE_REQUIRED_VERSION "3.6.100")
+set (CORE_REQUIRED_VERSION "3.6.101")
 
 add_definitions (-std=gnu99 -Wall -Werror-implicit-function-declaration) # -Wextra -Wwrite-strings -Wuninitialized -Werror-implicit-function-declaration -Wstrict-prototypes -Wreturn-type -Wparentheses -Warray-bounds)
 if (NOT DEFINED CMAKE_BUILD_TYPE)
@@ -72,6 +72,7 @@ pkg_get_variable(localedir          gldi plugins_locale)
 pkg_get_variable(gettext_domain     gldi plugins_gettext)
 pkg_get_variable(gtkversion         gldi gtkversion)
 pkg_get_variable(pkgdatadir         gldi pkgdatadir)
+pkg_get_variable(HAVE_WAYLAND       gldi have_wayland)
 
 # check that installation dir matches with the core
 if (NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "${prefix}")
@@ -128,6 +129,7 @@ pkg_check_modules ("PACKAGE" REQUIRED "gldi" "glib-2.0>=2.36")  # we check first
 STRING (REGEX REPLACE "gldi;" "" PACKAGE_LIBRARIES "${PACKAGE_LIBRARIES}")  # but we don't want to link to gldi, since we are dl-opened by it.
 
 # add_definitions (-DGTK_DISABLE_DEPRECATED="1")
+
 
 ############# SHARED-FILES #################
 set (shared_filesdatadir "${pluginsdatadir}/shared-files")
@@ -307,6 +309,18 @@ if (EXISTS ${DEBIAN_VERSION})
 	set (DEBIAN_PKG_MANAGERS "/usr/bin/apt-get /usr/bin/dpkg /usr/bin/aptitude")
 endif()
 
+############# WAYLAND PROTOCOLS #################
+set (HAVE_WAYLAND_PROTOCOLS 0)
+if (HAVE_WAYLAND)
+	find_package(ECM NO_MODULE)
+	if (ECM_FOUND)
+		set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH})
+		include (FindWaylandScanner)
+		if (WaylandScanner_FOUND)
+			set (HAVE_WAYLAND_PROTOCOLS 1)
+		endif()
+	endif()
+endif()
 
 
 ################################################################################
@@ -1200,16 +1214,40 @@ message (STATUS "> XGamma:")
 enable_if_not_defined (enable-xgamma)
 if (enable-xgamma)
 	pkg_check_modules (XGAMMA_PACKAGE x11 xxf86vm)
-	if (NOT XGAMMA_PACKAGE_FOUND)
-		message (STATUS "Could not find xxf86vm; Cairo-Dock won't be built with Xgamma applet.")
-		message (WARNING "These modules are required to compile XGamma applet: x11 and xxf86vm")
-		set (MODULES_MISSING "${MODULES_MISSING} x11 xxf86vm")
-		set (with_xgamma no)
+	set (HAVE_XGAMMA 1)
+	if (XGAMMA_PACKAGE_FOUND AND HAVE_WAYLAND_PROTOCOLS)
+		set (with_xgamma "yes (X11 and Wayland)")
 	else()
+		if (HAVE_WAYLAND_PROTOCOLS)
+			set (with_xgamma "yes (Wayland)")
+		else()
+			if (HAVE_WAYLAND)
+				message (STATUS "Cannot find extra-cmake-modules or wayland-scanner; Xgamma applet will not be built with Wayland support.")
+				set (MODULES_MISSING "${MODULES_MISSING} wayland-scanner extra-cmake-modules")
+			else()
+				message (STATUS "Core does not support Wayland; Xgamma applet will not be built with Wayland support.")
+			endif()
+		endif()
+		
+		if (XGAMMA_PACKAGE_FOUND)
+			set (with_xgamma "yes (X11)")
+		else()
+			message (STATUS "Could not find xxf86vm; Xgamma applet will not support X11.")
+			message (WARNING "These modules are required to compile XGamma applet with X11 support: x11 and xxf86vm")
+			set (MODULES_MISSING "${MODULES_MISSING} x11 xxf86vm")
+		endif()
+		
+		if (NOT XGAMMA_PACKAGE_FOUND AND NOT HAVE_WAYLAND_PROTOCOLS)
+			set (with_xgamma no)
+			set (HAVE_XGAMMA 0)
+			message (STATUS "Xgamma applet will not be built (neither X11 nor Wayland supported)")
+		endif()
+	endif()
+	
+	if (HAVE_XGAMMA)
 		set (GETTEXT_XGAMMA ${GETTEXT_PLUGINS})
 		set (VERSION_XGAMMA "1.2.5")
 		set (PACKAGE_XGAMMA "cd-Xgamma")
-		set (with_xgamma yes)
 		set (xgammadatadir "${pluginsdatadir}/Xgamma")
 		configure_file (${CMAKE_CURRENT_SOURCE_DIR}/Xgamma/data/Xgamma.conf.in ${CMAKE_CURRENT_BINARY_DIR}/Xgamma/data/Xgamma.conf)
 		add_subdirectory ("Xgamma")

--- a/Remote-Control/src/applet-init.c
+++ b/Remote-Control/src/applet-init.c
@@ -39,13 +39,17 @@ CD_APPLET_DEFINE2_BEGIN ("Remote-Control",
 	"Escape or the same shortkey will cancel."),
 	"Fabounet (Fabrice Rey)")
 	
+	CD_APPLET_REDEFINE_TITLE (N_("Control from keyboard"))
+	
 	if (gldi_container_is_wayland_backend ())
 		if (strcmp (gldi_wayland_get_detected_compositor(), "Wayfire"))
-			return FALSE;
+		{
+			gldi_module_disable (pModule, _("This applet requires global keyboard shortcuts. You are currently running Cairo-Dock in\na Wayland session where this functionality is not supported. See here for more information:\nhttps://github.com/Cairo-Dock/cairo-dock-core/wiki/Wayland-support"));
+			return;
+		}
 	
 	CD_APPLET_DEFINE_COMMON_APPLET_INTERFACE
 	CD_APPLET_SET_CONTAINER_TYPE (CAIRO_DOCK_MODULE_IS_PLUGIN);
-	CD_APPLET_REDEFINE_TITLE (N_("Control from keyboard"))
 CD_APPLET_DEFINE2_END
 
 static gboolean _menu_request (G_GNUC_UNUSED gpointer dummy, G_GNUC_UNUSED GldiManager* pManager)

--- a/Xgamma/src/CMakeLists.txt
+++ b/Xgamma/src/CMakeLists.txt
@@ -13,6 +13,13 @@ SET(cd-Xgamma_LIB_SRCS
 	applet-xgamma.h
 )
 
+if (HAVE_WAYLAND_PROTOCOLS)
+	ecm_add_wayland_client_protocol(
+		cd-Xgamma_LIB_SRCS
+		PROTOCOL "wlr-gamma-control-unstable-v1.xml"
+		BASENAME "wlr-gamma-control")
+endif()
+
 add_library(${PACKAGE_XGAMMA} SHARED ${cd-Xgamma_LIB_SRCS})
 
 ########### compil ###############
@@ -25,9 +32,17 @@ add_definitions (-DMY_APPLET_GETTEXT_DOMAIN="${GETTEXT_XGAMMA}")
 add_definitions (-DMY_APPLET_DOCK_VERSION="${dock_version}")
 add_definitions (-DMY_APPLET_ICON_FILE="icon.png")
 
+if (XGAMMA_PACKAGE_FOUND)
+	add_definitions (-DXGAMMA_X11=1)
+endif()
+if (HAVE_WAYLAND_PROTOCOLS)
+	add_definitions (-DXGAMMA_WAYLAND=1)
+endif()
+
 include_directories (
 	${PACKAGE_INCLUDE_DIRS}
-	${XGAMMA_PACKAGE_INCLUDE_DIRS})
+	${XGAMMA_PACKAGE_INCLUDE_DIRS}
+	${CMAKE_CURRENT_BINARY_DIR})
 
 link_directories (
 	${PACKAGE_LIBRARY_DIRS}

--- a/Xgamma/src/applet-init.c
+++ b/Xgamma/src/applet-init.c
@@ -17,16 +17,6 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdio.h>
-#include <errno.h>
-#include <X11/Xos.h>
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <X11/extensions/xf86vmode.h>
-#include <ctype.h>
-#include <stdlib.h>
-#include <gdk/gdkx.h>
-
 #include <cairo-dock.h>
 
 #include "applet-config.h"
@@ -35,11 +25,9 @@
 #include "applet-struct.h"
 #include "applet-init.h"
 
-static gboolean s_bVideoExtensionChecked = FALSE;
-
 
 CD_APPLET_DEFINE2_BEGIN ("Xgamma",
-	CAIRO_DOCK_MODULE_SUPPORTS_X11,
+	CAIRO_DOCK_MODULE_DEFAULT_FLAGS,
 	CAIRO_DOCK_CATEGORY_APPLET_SYSTEM,
 	N_("Setup the luminosity of your screen directly from your dock.\n"
 	"Scroll up/down to increase/decrease the luminosity\n"
@@ -50,6 +38,26 @@ CD_APPLET_DEFINE2_BEGIN ("Xgamma",
 	CD_APPLET_DEFINE_COMMON_APPLET_INTERFACE
 	CD_APPLET_ALLOW_EMPTY_TITLE
 	CD_APPLET_REDEFINE_TITLE (N_("Screen Luminosity"))
+	
+	if (gldi_container_is_wayland_backend ())
+	{
+#ifdef XGAMMA_WAYLAND
+		if (! xgamma_setup_wayland ())
+			gldi_module_disable (pModule, D_("You're running on a Wayland compositor that does not support the \"wlr-gamma-control\" protocol."));
+#else
+		gldi_module_disable (pModule, D_("Xgamma applet was not built with Wayland support."));
+#endif
+	}
+	else
+	{
+#ifdef XGAMMA_X11
+		if (! xgamma_setup_x11 ())
+			gldi_module_disable (pModule, D_("You're running on an X server without support for the \"XF86VidMode\" extension."));
+#else
+		gldi_module_disable (pModule, D_("Xgamma applet was not built with X11 support."));
+#endif
+	}
+	
 CD_APPLET_DEFINE2_END
 
 
@@ -69,48 +77,18 @@ CD_APPLET_INIT_BEGIN
 		"Configuration", "shortkey",
 		(CDBindkeyHandler) cd_xgamma_on_keybinding_pull2);
 	
-	if (! s_bVideoExtensionChecked)
+	xgamma_init ();
+	
+	if (myConfig.fInitialGamma != 0)
 	{
-		s_bVideoExtensionChecked = TRUE;
+		cd_message ("Applying luminosity as defined in config (gamma=%.2f)...", myConfig.fInitialGamma);
+		xgamma_get_gamma (&myData.Xgamma);
+		myConfig.fInitialGamma = MIN (GAMMA_MAX, MAX (myConfig.fInitialGamma, GAMMA_MIN));
+		myData.Xgamma.red = myConfig.fInitialGamma;
+		myData.Xgamma.blue = myConfig.fInitialGamma;
+		myData.Xgamma.green = myConfig.fInitialGamma;
+		xgamma_set_gamma (&myData.Xgamma);
 		
-		Display *dpy = gdk_x11_get_default_xdisplay ();
-		if (dpy == NULL)
-		{
-			cd_warning ("Xgamma : unable to get X display");
-			return ;
-		}
-		
-		//#ifdef XF86VidModeQueryVersion
-		int MajorVersion, MinorVersion;
-		if (!XF86VidModeQueryVersion(dpy, &MajorVersion, &MinorVersion))
-		{
-			cd_warning ("Xgamma : unable to query video extension version");
-			return ;
-		}
-		//#endif
-		
-		//#ifdef XF86VidModeQueryExtension
-		int EventBase, ErrorBase;
-		if (!XF86VidModeQueryExtension(dpy, &EventBase, &ErrorBase))
-		{
-			cd_warning ("Xgamma : unable to query video extension information");
-			return ;
-		}
-		//#endif
-		
-		myData.bVideoExtensionOK = TRUE;
-		
-		if (myConfig.fInitialGamma != 0)
-		{
-			cd_message ("Applying luminosity as defined in config (gamma=%.2f)...", myConfig.fInitialGamma);
-			xgamma_get_gamma (&myData.Xgamma);
-			myConfig.fInitialGamma = MIN (GAMMA_MAX, MAX (myConfig.fInitialGamma, GAMMA_MIN));
-			myData.Xgamma.red = myConfig.fInitialGamma;
-			myData.Xgamma.blue = myConfig.fInitialGamma;
-			myData.Xgamma.green = myConfig.fInitialGamma;
-			xgamma_set_gamma (&myData.Xgamma);
-			
-		}
 	}
 	
 	if (myDesklet)  // on cree le widget pour avoir qqch a afficher dans le desklet.
@@ -138,6 +116,8 @@ CD_APPLET_STOP_BEGIN
 	
 	gldi_object_unref (GLDI_OBJECT(myData.pKeyBinding));
 	gldi_object_unref (GLDI_OBJECT(myData.pKeyBinding2));
+	
+	xgamma_stop ();
 	
 	if (myData.iSidScrollAction != 0)
 		g_source_remove (myData.iSidScrollAction);

--- a/Xgamma/src/applet-struct.h
+++ b/Xgamma/src/applet-struct.h
@@ -30,8 +30,6 @@
 #define GAMMA_MAX 2.0
 
 #include <cairo-dock.h>
-#include <X11/Xlib.h>
-#include <X11/extensions/xf86vmode.h>
 
 struct _AppletConfig {
 	gint iScrollVariation;
@@ -40,6 +38,13 @@ struct _AppletConfig {
 	gchar *cShortkey;
 	gchar *cShortkey2;
 	} ;
+
+/// same as XF86VidModeGamma struct, but that might not be available
+typedef struct _CDGamma {
+	float red;
+	float green;
+	float blue;
+	} CDGamma;
 
 struct _AppletData {
 	gboolean bVideoExtensionOK;
@@ -53,8 +58,8 @@ struct _AppletData {
 	guint iRedScaleSignalID;
 	guint iGreenScaleSignalID;
 	guint iBlueScaleSignalID;
-	XF86VidModeGamma Xgamma;
-	XF86VidModeGamma XoldGamma;
+	CDGamma Xgamma;
+	CDGamma XoldGamma;
 	guint iSidScrollAction;
 	gint iScrollCount;
 	GldiShortkey *pKeyBinding;

--- a/Xgamma/src/applet-xgamma.c
+++ b/Xgamma/src/applet-xgamma.c
@@ -17,32 +17,319 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifdef XGAMMA_WAYLAND
+#define _GNU_SOURCE // needed for memfd_create
+#include <cairo-dock-wayland-manager.h>
+#include "wayland-wlr-gamma-control-client-protocol.h"
+
+#include <sys/mman.h> // memfd_create
+#include <stdlib.h> // mkostemp
+#include <unistd.h> // unlink
+#include <fcntl.h>
+#include <gdk/gdkwayland.h>
+
+#endif
+
+#ifdef XGAMMA_X11
 #include <gdk/gdkx.h>
+#include <X11/Xos.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/xf86vmode.h>
+#endif
 
 #include <cairo-dock.h>
-
 #include "applet-struct.h"
 #include "applet-xgamma.h"
 
-static gboolean s_bUseXf86VidMode = FALSE;
+gboolean s_bX11 = FALSE;
+gboolean s_bWayland = FALSE;
 
-static gboolean _xf86vidmode_supported (void)
+#ifdef XGAMMA_WAYLAND
+struct zwlr_gamma_control_manager_v1 *s_pManager = NULL;
+static CDGamma s_gamma_req = {1.0, 1.0, 1.0};
+
+gboolean xgamma_setup_wayland (void)
 {
-	static gboolean s_bXf86VidModeChecked = FALSE;
-	if (s_bXf86VidModeChecked)
-		return s_bUseXf86VidMode;
+	const GldiWaylandProtocolInfo *info = gldi_wayland_get_global (zwlr_gamma_control_manager_v1_interface.name);
+	if (info) s_bWayland = TRUE;
+	return s_bWayland;
+}
+#endif
 
-	int event_base, error_base;
+#ifdef XGAMMA_X11
+gboolean xgamma_setup_x11 (void)
+{
 	Display *dpy = gdk_x11_get_default_xdisplay ();
-	if (! XF86VidModeQueryExtension (dpy, &event_base, &error_base))  // on regarde si le serveur X supporte l'extension.
+	if (dpy == NULL)
 	{
-		cd_warning ("XF86VidMode extension not available.");
-		s_bUseXf86VidMode = FALSE;
+		// should not happen, backend checked by caller
+		cd_warning ("Xgamma : unable to get X display");
+		return FALSE;
 	}
-	else
-		s_bUseXf86VidMode = TRUE;
-	s_bXf86VidModeChecked = TRUE;
-	return s_bUseXf86VidMode;
+	
+	int MajorVersion, MinorVersion;
+	if (!XF86VidModeQueryVersion(dpy, &MajorVersion, &MinorVersion))
+	{
+		cd_warning ("Xgamma : unable to query video extension version");
+		return FALSE;
+	}
+	
+	int EventBase, ErrorBase;
+	if (!XF86VidModeQueryExtension(dpy, &EventBase, &ErrorBase))
+	{
+		cd_warning ("Xgamma : unable to query video extension information");
+		return FALSE;
+	}
+	
+	s_bX11 = TRUE;
+	return TRUE;
+}
+#endif
+
+
+#ifdef XGAMMA_WAYLAND
+
+typedef struct _XGammaMonitor {
+	struct zwlr_gamma_control_v1 *pGammaControl;
+	uint32_t uGammaSize;
+} XGammaMonitor;
+
+static GHashTable *s_pMonitors; // key: GdkMonitor*, value: XGammaMonitor* (owned)
+
+#ifdef __linux__
+#define HAVE_MEMFD
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#if __FreeBSD_version >= 1300000
+#define HAVE_MEMFD
+#endif
+#endif
+
+#ifdef __NetBSD__
+#include <sys/param.h>
+#if __NetBSD_Version__ >= 1100000000
+#define HAVE_MEMFD
+#endif
+#endif
+
+static void _set_gamma_wayland (const CDGamma *pGamma, XGammaMonitor *pMonitor)
+{
+	// we need to create an anonymous fd and fill it with the gamma table
+	int fd = -1;
+#ifdef HAVE_MEMFD
+	// memfd_create () is supported on Linux 3.17 and newer; also FreeBSD 13
+	// and NetBSD 11
+	fd = memfd_create ("Cairo-Dock-XGamma", MFD_CLOEXEC | MFD_ALLOW_SEALING);
+#else
+	// mkostemp () is supported on at least FreeBSD 10.0 (released in 2014),
+	// NetBSD 7.0 (2015), OpenBSD 5.7 (2015) and DragonflyBSD 4.8 (2017)
+	char *tmpname = g_strdup_printf ("%s/cd-xgamma-XXXXXX", g_get_tmp_dir ());
+	fd = mkostemp (tmpname, O_CLOEXEC);
+	if (fd >= 0) unlink (tmpname); // delete the file, only keep the fd
+	g_free (tmpname);
+#endif
+	if (fd == -1)
+	{
+		cd_warning ("Cannot create memfd");
+		return;
+	}
+	
+	const size_t len = pMonitor->uGammaSize;
+	const off_t n_bytes = len * 3UL * sizeof (uint16_t);
+	if (ftruncate (fd, n_bytes))
+	{
+		close (fd);
+		cd_warning ("Cannot set file size");
+		return;
+	}
+	
+	void *data = mmap (NULL, n_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (data == MAP_FAILED)
+	{
+		close (fd);
+		cd_warning ("Cannot mmap");
+		return;
+	}
+	
+	uint16_t *tbl = (uint16_t*)data;
+	size_t i;
+	for (i = 0; i < 3; i++)
+	{
+		const size_t base = i * len;
+		float gamma;
+		switch (i)
+		{
+			case 0: gamma = pGamma->red; break;
+			case 1: gamma = pGamma->green; break;
+			case 2: gamma = pGamma->blue; break;
+		}
+		
+		gamma = 1.0f / gamma;
+		size_t j;
+		for (j = 0; j < len; j++)
+		{
+			float x = ((float)j) / ((float)len);
+			x = powf (x, gamma);
+			tbl[base + j] = (uint16_t)(UINT16_MAX * x);
+		}
+	}
+	
+	munmap (data, n_bytes);
+#ifdef HAVE_MEMFD
+	// seals available since Linux 3.17
+	if (fcntl (fd, F_ADD_SEALS, F_SEAL_GROW | F_SEAL_SHRINK | F_SEAL_WRITE) == -1)
+		cd_warning ("Cannot seal fd");
+#endif
+	
+	zwlr_gamma_control_v1_set_gamma (pMonitor->pGammaControl, fd);
+	close (fd);
+}
+
+static void _set_gamma_wayland2 (G_GNUC_UNUSED gpointer key, gpointer value,
+	G_GNUC_UNUSED gpointer user_data)
+{
+	XGammaMonitor *pMonitor = (XGammaMonitor*)value;
+	if (pMonitor->pGammaControl && pMonitor->uGammaSize)
+		_set_gamma_wayland (&s_gamma_req, pMonitor);
+}
+
+static void _got_gamma_size (void *data,
+	G_GNUC_UNUSED struct zwlr_gamma_control_v1 *zwlr_gamma_control_v1, uint32_t size)
+{
+	XGammaMonitor *pMonitor = (XGammaMonitor*)data;
+	pMonitor->uGammaSize = size;
+	if (s_gamma_req.red != 1.0 || s_gamma_req.green != 1.0 || s_gamma_req.blue != 1.0)
+		_set_gamma_wayland (&s_gamma_req, pMonitor);
+}
+
+static void _gamma_control_failed (void *data, struct zwlr_gamma_control_v1 *pGammaControl)
+{
+	cd_warning ("Gamma control is unavailable");
+	zwlr_gamma_control_v1_destroy (pGammaControl);
+	XGammaMonitor *pMonitor = (XGammaMonitor*)data;
+	pMonitor->pGammaControl = NULL;
+	pMonitor->uGammaSize = 0;
+}
+
+static struct zwlr_gamma_control_v1_listener s_gamma_control_listener = {
+	.gamma_size = _got_gamma_size,
+	.failed = _gamma_control_failed
+};
+
+void _delete_monitor (gpointer data)
+{
+	XGammaMonitor *pMonitor = (XGammaMonitor*)data;
+	if (pMonitor->pGammaControl) zwlr_gamma_control_v1_destroy (pMonitor->pGammaControl);
+	g_free (pMonitor);
+}
+
+gboolean _xgamma_wayland_monitor_added (G_GNUC_UNUSED gpointer user_data, GdkMonitor *monitor)
+{
+	if (!g_hash_table_contains (s_pMonitors, monitor))
+	{
+		XGammaMonitor *pMonitor = g_new0 (XGammaMonitor, 1);
+		struct wl_output *output = gdk_wayland_monitor_get_wl_output (monitor);
+		pMonitor->pGammaControl = zwlr_gamma_control_manager_v1_get_gamma_control (s_pManager, output);
+		zwlr_gamma_control_v1_add_listener (pMonitor->pGammaControl, &s_gamma_control_listener, pMonitor);
+		g_hash_table_insert (s_pMonitors, monitor, pMonitor);
+	}
+	return GLDI_NOTIFICATION_LET_PASS;
+}
+
+gboolean _xgamma_wayland_monitor_removed (G_GNUC_UNUSED gpointer user_data, GdkMonitor *monitor)
+{
+	g_hash_table_remove (s_pMonitors, monitor);
+	return GLDI_NOTIFICATION_LET_PASS;
+}
+
+#endif
+
+
+void xgamma_init (void)
+{
+#ifdef XGAMMA_WAYLAND
+	if (s_bWayland)
+	{
+		s_gamma_req.red = 1.0f;
+		s_gamma_req.green = 1.0f;
+		s_gamma_req.blue = 1.0f;
+		
+		const GldiWaylandProtocolInfo *info = gldi_wayland_get_global (zwlr_gamma_control_manager_v1_interface.name);
+		struct wl_registry *registry = gldi_wayland_get_registry ();
+		if (! (info && registry))
+		{
+			cd_warning ("wlr-gamma-control disappeared");
+			return;
+		}
+		
+		uint32_t version = info->version;
+		if (version > (uint32_t)zwlr_gamma_control_manager_v1_interface.version)
+			version = zwlr_gamma_control_manager_v1_interface.version;
+		
+		s_pManager = wl_registry_bind (registry, info->id, &zwlr_gamma_control_manager_v1_interface, version);
+		if (!s_pManager)
+		{
+			cd_warning ("Cannot bind wlr-gamma-control manager");
+			return;
+		}
+		
+		s_pMonitors = g_hash_table_new_full (NULL, NULL, NULL, _delete_monitor);
+		int n_outputs = 0, i;
+		GdkMonitor *const *monitors = gldi_desktop_get_monitors (&n_outputs);
+		for (i = 0; i < n_outputs; i++) _xgamma_wayland_monitor_added (NULL, monitors[i]);
+		
+		gldi_object_register_notification (&myDesktopMgr, NOTIFICATION_DESKTOP_MONITOR_ADDED,
+			(GldiNotificationFunc) _xgamma_wayland_monitor_added, GLDI_RUN_FIRST, NULL);
+		gldi_object_register_notification (&myDesktopMgr, NOTIFICATION_DESKTOP_MONITOR_REMOVED,
+			(GldiNotificationFunc) _xgamma_wayland_monitor_removed, GLDI_RUN_FIRST, NULL);
+		
+		return;
+	}
+#endif
+
+#ifdef XGAMMA_X11
+	if (s_bX11)
+	{
+		// nothing to do
+		return;
+	}
+#endif
+	
+	cd_warning ("no supported method for setting gamma");
+}
+
+void xgamma_stop (void)
+{
+#ifdef XGAMMA_WAYLAND
+	if (s_bWayland)
+	{
+		gldi_object_remove_notification (&myDesktopMgr, NOTIFICATION_DESKTOP_MONITOR_ADDED,
+			(GldiNotificationFunc) _xgamma_wayland_monitor_added, NULL);
+		gldi_object_remove_notification (&myDesktopMgr, NOTIFICATION_DESKTOP_MONITOR_REMOVED,
+			(GldiNotificationFunc) _xgamma_wayland_monitor_removed, NULL);
+		
+		if (s_pMonitors)
+		{
+			g_hash_table_destroy (s_pMonitors);
+			s_pMonitors = NULL;
+		}
+		if (s_pManager)
+		{
+			zwlr_gamma_control_manager_v1_destroy (s_pManager);
+			s_pManager = NULL;
+		}
+	}
+#endif
+}
+
+
+static void _clamp_gamma (float *x)
+{
+	if (*x < GAMMA_MIN) *x = GAMMA_MIN;
+	else if (*x > GAMMA_MAX) *x = GAMMA_MAX;
 }
 
 static inline double _gamma_to_percent (double fGamma)
@@ -63,7 +350,7 @@ static inline double _percent_to_gamma (double fGammaPercent)
 	return GAMMA_MIN + fGammaPercent / 100. * (GAMMA_MAX - GAMMA_MIN);
 }
 
-void xgamma_add_gamma (XF86VidModeGamma *pGamma, gint iNbSteps)
+void xgamma_add_gamma (CDGamma *pGamma, gint iNbSteps)
 {
 	if (iNbSteps == 0)
 		return;
@@ -79,41 +366,79 @@ void xgamma_add_gamma (XF86VidModeGamma *pGamma, gint iNbSteps)
 	xgamma_set_gamma (&myData.Xgamma);
 }
 
-double xgamma_get_gamma (XF86VidModeGamma *pGamma)
+double xgamma_get_gamma (CDGamma *pGamma)
 {
 	g_return_val_if_fail (pGamma != NULL, 1);
-	Display *dpy = gdk_x11_get_default_xdisplay ();
 	
-	g_return_val_if_fail (_xf86vidmode_supported (), 1.);
-	if (!XF86VidModeGetGamma (dpy, DefaultScreen (dpy), pGamma))
+#ifdef XGAMMA_WAYLAND
+	if (s_bWayland)
 	{
-		cd_warning ("Xgamma : unable to query gamma correction");
-		return 1.;
+		*pGamma = s_gamma_req;
 	}
+#endif
+	
+#ifdef XGAMMA_X11
+	if (s_bX11)
+	{
+		Display *dpy = gdk_x11_get_default_xdisplay ();
+		
+		XF86VidModeGamma gamma1;
+		if (!XF86VidModeGetGamma (dpy, DefaultScreen (dpy), &gamma1))
+		{
+			cd_warning ("Xgamma : unable to query gamma correction");
+			return 1.;
+		}
+		pGamma->red = gamma1.red;
+		pGamma->green = gamma1.green;
+		pGamma->blue = gamma1.blue;
+	}
+#endif
+	
 	double fGamma = (pGamma->red + pGamma->blue + pGamma->green) / 3;
 	cd_debug ("Gamma: %f, %f, %f, %f",
 		pGamma->red, pGamma->blue, pGamma->green, fGamma);
 	return fGamma;
 }
 
-
-void xgamma_set_gamma (XF86VidModeGamma *pGamma)
+void xgamma_set_gamma (CDGamma *pGamma)
 {
 	g_return_if_fail (pGamma != NULL);
-	Display *dpy = gdk_x11_get_default_xdisplay ();
 	
-	g_return_if_fail (_xf86vidmode_supported ());
-	if (!XF86VidModeSetGamma(dpy, DefaultScreen (dpy), pGamma))
+	_clamp_gamma (&pGamma->red);
+	_clamp_gamma (&pGamma->green);
+	_clamp_gamma (&pGamma->blue);
+	
+#ifdef XGAMMA_WAYLAND
+	if (s_bWayland)
 	{
-		cd_warning ("Xgamma : unable to set gamma correction");
+		g_return_if_fail (s_pMonitors != NULL);
+		s_gamma_req = *pGamma;
+		g_hash_table_foreach (s_pMonitors, _set_gamma_wayland2, NULL);
 	}
-	else
+#endif
+	
+#ifdef XGAMMA_X11
+	if (s_bX11)
 	{
-		if (myConfig.cDefaultTitle == NULL)
+		Display *dpy = gdk_x11_get_default_xdisplay ();
+		
+		XF86VidModeGamma gamma1;
+		gamma1.red = pGamma->red;
+		gamma1.green = pGamma->green;
+		gamma1.blue = pGamma->blue;
+		
+		if (!XF86VidModeSetGamma(dpy, DefaultScreen (dpy), &gamma1))
 		{
-			double fGamma = (pGamma->red + pGamma->blue + pGamma->green) / 3;
-			cd_gamma_display_gamma_on_label (fGamma);
+			cd_warning ("Xgamma : unable to set gamma correction");
+			return;
 		}
+	}
+#endif
+	
+	if (myConfig.cDefaultTitle == NULL)
+	{
+		double fGamma = (pGamma->red + pGamma->blue + pGamma->green) / 3;
+		cd_gamma_display_gamma_on_label (fGamma);
 	}
 }
 
@@ -208,7 +533,7 @@ static GtkWidget *_xgamma_add_channel_widget (GtkWidget *pInteractiveWidget, con
 
 	return pHScale;
 }
-void xgamma_create_scales_widget (double fGamma, XF86VidModeGamma *pGamma)
+void xgamma_create_scales_widget (double fGamma, CDGamma *pGamma)
 {
 	myData.pWidget = gtk_grid_new ();
 
@@ -259,6 +584,7 @@ void xgamma_build_and_show_widget (void)
 {
 	double fGamma = xgamma_get_gamma (&myData.Xgamma);
 	g_return_if_fail (fGamma >= 0);
+	myData.XoldGamma = myData.Xgamma;
 	
 	xgamma_create_scales_widget (fGamma, &myData.Xgamma);
 	

--- a/Xgamma/src/applet-xgamma.h
+++ b/Xgamma/src/applet-xgamma.h
@@ -22,22 +22,30 @@
 
 #include <stdio.h>
 #include <errno.h>
-#include <X11/Xos.h>
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <X11/extensions/xf86vmode.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include "applet-struct.h"
+
+#ifdef XGAMMA_WAYLAND
+gboolean xgamma_setup_wayland (void);
+#endif
+
+#ifdef XGAMMA_X11
+gboolean xgamma_setup_x11 (void);
+#endif
+
+void xgamma_init (void);
+
+void xgamma_stop (void);
+
+void xgamma_add_gamma (CDGamma *pGamma, gint iNbSteps);
+
+double xgamma_get_gamma (CDGamma *pGamma);
+
+void xgamma_set_gamma (CDGamma *pGamma);
 
 
-void xgamma_add_gamma (XF86VidModeGamma *pGamma, gint iNbSteps);
-
-double xgamma_get_gamma (XF86VidModeGamma *pGamma);
-
-void xgamma_set_gamma (XF86VidModeGamma *pGamma);
-
-
-void xgamma_create_scales_widget (double fGamma, XF86VidModeGamma *pGamma);
+void xgamma_create_scales_widget (double fGamma, CDGamma *pGamma);
 
 
 CairoDialog *xgamma_build_dialog (void);

--- a/Xgamma/src/wlr-gamma-control-unstable-v1.xml
+++ b/Xgamma/src/wlr-gamma-control-unstable-v1.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_gamma_control_unstable_v1">
+  <copyright>
+    Copyright © 2015 Giulio camuffo
+    Copyright © 2018 Simon Ser
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="manage gamma tables of outputs">
+    This protocol allows a privileged client to set the gamma tables for
+    outputs.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_gamma_control_manager_v1" version="1">
+    <description summary="manager to create per-output gamma controls">
+      This interface is a manager that allows creating per-output gamma
+      controls.
+    </description>
+
+    <request name="get_gamma_control">
+      <description summary="get a gamma control for an output">
+        Create a gamma control that can be used to adjust gamma tables for the
+        provided output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_gamma_control_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_gamma_control_v1" version="1">
+    <description summary="adjust gamma tables for an output">
+      This interface allows a client to adjust gamma tables for a particular
+      output.
+
+      The client will receive the gamma size, and will then be able to set gamma
+      tables. At any time the compositor can send a failed event indicating that
+      this object is no longer valid.
+
+      There can only be at most one gamma control object per output, which
+      has exclusive access to this particular output. When the gamma control
+      object is destroyed, the gamma table is restored to its original value.
+    </description>
+
+    <event name="gamma_size">
+      <description summary="size of gamma ramps">
+        Advertise the size of each gamma ramp.
+
+        This event is sent immediately when the gamma control object is created.
+      </description>
+      <arg name="size" type="uint" summary="number of elements in a ramp"/>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_gamma" value="1" summary="invalid gamma tables"/>
+    </enum>
+
+    <request name="set_gamma">
+      <description summary="set the gamma table">
+        Set the gamma table. The file descriptor can be memory-mapped to provide
+        the raw gamma table, which contains successive gamma ramps for the red,
+        green and blue channels. Each gamma ramp is an array of 16-byte unsigned
+        integers which has the same length as the gamma size.
+
+        The file descriptor data must have the same length as three times the
+        gamma size.
+      </description>
+      <arg name="fd" type="fd" summary="gamma table file descriptor"/>
+    </request>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the gamma control is no longer valid. This
+        can happen for a number of reasons, including:
+        - The output doesn't support gamma tables
+        - Setting the gamma tables failed
+        - Another client already has exclusive gamma control for this output
+        - The compositor has transferred gamma control to another client
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this control">
+        Destroys the gamma control object. If the object is still valid, this
+        restores the original gamma tables.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/gnome-integration/src/applet-init.c
+++ b/gnome-integration/src/applet-init.c
@@ -43,5 +43,5 @@ CD_APPLET_INIT_BEGIN
 		// (this means that if GNOME environment is detected, this applet will always show as "enabled",
 		// but will only be active if the DBus session proxy have been found)
 	}
-	else gldi_module_disable (myApplet->pModule, D_("Not running in a GNOME or Cinnamon session."));
+	else gldi_module_disable (myApplet->pModule, D_("This applet is only supported in a GNOME or Cinnamon session.\nIf you believe it should work in your setup, please open a bug report at:\nhttps://github.com/Cairo-Dock/cairo-dock-core/issues"));
 CD_APPLET_INIT_END

--- a/kde-integration/src/applet-init.c
+++ b/kde-integration/src/applet-init.c
@@ -47,8 +47,9 @@ CD_APPLET_DEFINE2_BEGIN ("kde integration",
 		VFSBackend.setup_time = env_backend_setup_time;
 		VFSBackend.show_system_monitor = env_backend_show_system_monitor;
 		cairo_dock_fm_register_vfs_backend (&VFSBackend, TRUE); // TRUE: overwrite previously registered functions
+		
+		CD_APPLET_SET_CONTAINER_TYPE (CAIRO_DOCK_MODULE_IS_PLUGIN);
 	}
-	else
-		return FALSE;
-	CD_APPLET_SET_CONTAINER_TYPE (CAIRO_DOCK_MODULE_IS_PLUGIN);
+	else gldi_module_disable (pModule, _("This applet is only supported in a KDE (Plasma) session.\nIf you believe it should work in your setup, please open a bug report at:\nhttps://github.com/Cairo-Dock/cairo-dock-core/issues"));
+	
 CD_APPLET_DEFINE2_END

--- a/weather/src/applet-config.c
+++ b/weather/src/applet-config.c
@@ -17,6 +17,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include <string.h>
 #include <glib/gstdio.h>
 

--- a/weather/src/applet-load-icons.c
+++ b/weather/src/applet-load-icons.c
@@ -17,6 +17,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include <string.h>
 
 #include "applet-struct.h"

--- a/weather/src/applet-read-data.c
+++ b/weather/src/applet-read-data.c
@@ -17,6 +17,7 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <math.h>
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/xfce-integration/src/applet-init.c
+++ b/xfce-integration/src/applet-init.c
@@ -40,8 +40,8 @@ CD_APPLET_DEFINE2_BEGIN ("xfce integration",
 		VFSBackend.setup_time = env_backend_setup_time;
 		VFSBackend.show_system_monitor = env_backend_show_system_monitor;
 		cairo_dock_fm_register_vfs_backend (&VFSBackend, TRUE); // TRUE: overwrite previously registered functions
+		
+		CD_APPLET_SET_CONTAINER_TYPE (CAIRO_DOCK_MODULE_IS_PLUGIN);
 	}
-	else
-		return FALSE;
-	CD_APPLET_SET_CONTAINER_TYPE (CAIRO_DOCK_MODULE_IS_PLUGIN);
+	else gldi_module_disable (pModule, _("This applet is only supported in an Xfce session.\nIf you believe it should work in your setup, please open a bug report at:\nhttps://github.com/Cairo-Dock/cairo-dock-core/issues"));
 CD_APPLET_DEFINE2_END


### PR DESCRIPTION
Based on the [wlr-gamma-control](https://wayland.app/protocols/wlr-gamma-control-unstable-v1) protocol.

Depends on https://github.com/Cairo-Dock/cairo-dock-core/pull/273

TODO:
- [x] multi-monitor support
- [x] test when either X11 or Wayland support is not available
- [x] test when the protocol is not supported